### PR TITLE
Support geom_step

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -196,7 +196,8 @@ markLegends <-
   list(point=c("colour", "fill", "shape"),
        path=c("linetype", "size", "colour"),
        polygon=c("colour", "fill", "linetype", "size", "group"),
-       bar=c("fill"))
+       bar=c("fill"),
+       step=c("linetype", "size", "colour"))
 
 markUnique <- as.character(unique(unlist(markLegends)))
 

--- a/inst/tests/test-ggplot-step.R
+++ b/inst/tests/test-ggplot-step.R
@@ -1,16 +1,50 @@
 context("Step")
 
 # Dataset for test
-oranges <- subset(Orange, Tree == 1, select=-Tree)
-# Line shapes available in plotly
-shapes <- c("linear", "spline", "hv", "vh", "hvh", "vhv")
+oranges <- subset(Orange, Tree %in% c(1, 2))
+# Line shapes available in plotly: "linear", "spline", "hv", "vh", "hvh", "vhv"
 
-gg <- ggplot(oranges, aes(x=age, y=circumference))
+gg <- ggplot(oranges, aes(x=age, y=circumference,
+                          group=Tree, colour=factor(Tree)))
 
-for (d in shapes) {
-  test_that("direction is translated to shape (same values)", {
-    gg.dir <- gg + geom_step(direction=d)
-    L <- gg2list(gg.dir)
-    expect_identical(L[[1]]$line$shape, d)
-  })
-}
+test_that("direction of geom_line is translated to shape=linear", {
+  gg.linear <- gg + geom_line()
+  L <- gg2list(gg.linear)
+  expect_equal(length(L), 3)
+  expect_identical(L[[1]]$line$shape, "linear")
+})
+
+test_that("direction of geom_path is translated to shape=linear", {
+  gg.lin <- gg + geom_path()
+  L <- gg2list(gg.lin)
+  expect_equal(length(L), 3)
+  expect_identical(L[[1]]$line$shape, "linear")
+})
+
+test_that("direction hv is translated to shape=hv", {
+  gg.hv <- gg + geom_step()
+  L <- gg2list(gg.hv)
+  expect_equal(length(L), 3)
+  expect_identical(L[[1]]$line$shape, "hv")
+})
+
+test_that("direction vh is translated to shape=vh", {
+  gg.vh <- gg + geom_step(direction="vh")
+  L <- gg2list(gg.vh)
+  expect_equal(length(L), 3)
+  expect_identical(L[[1]]$line$shape, "vh")
+})
+
+test_that("direction hvh is translated to shape=hvh", {
+  gg.hvh <- gg + geom_step(direction="hvh")
+  L <- gg2list(gg.hvh)
+  expect_equal(length(L), 3)
+  expect_identical(L[[1]]$line$shape, "hvh")
+})
+
+test_that("direction vhv is translated to shape=vhv", {
+  gg.vhv <- gg + geom_step(direction="vhv")
+  L <- gg2list(gg.vhv)
+  expect_equal(length(L), 3)
+  expect_identical(L[[1]]$line$shape, "vhv")
+})


### PR DESCRIPTION
I followed suggestions by @tdhock to:
- avoid for loops in tests
- check that `geom_line` and `geom_path` end up with shape=linear
- support the conversion of different "linetype", "size", "colour" (Do we know how to handle "group"?)
