### PR TITLE
Handle the not yet supported stat_bin

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -235,20 +235,26 @@ gg2list <- function(p){
     if(!is.data.frame(p$layers[[layer.i]]$data)){
       p$layers[[layer.i]]$data <- p$data
     }
-    geom_type <- p$layers[[layer.i]]$geom
-    geom_type <- strsplit(capture.output(geom_type), "geom_")[[1]][2]
-    geom_type <- strsplit(geom_type, ": ")[[1]]
-    ## Barmode.
-    layout$barmode <- "group"
-    if (geom_type == "bar") {
-      pos <- capture.output(p$layers[[layer.i]]$position)
-      if (length(grep("identity", pos)) > 0) {
-        layout$barmode <- "overlay"
-      } else if (length(grep("stack", pos)) > 0) {
-        layout$barmode <- "stack"
-      }
+  }
+  geom_type <- p$layers[[layer.i]]$geom
+  geom_type <- strsplit(capture.output(geom_type), "geom_")[[1]][2]
+  geom_type <- strsplit(geom_type, ": ")[[1]]
+  ## Barmode.
+  layout$barmode <- "group"
+  if (geom_type == "bar") {
+    stat_type <- capture.output(p$layers[[layer.i]]$stat)
+    stat_type <- strsplit(stat_type, ": ")[[1]]
+    if (length(grep("identity", stat_type)) <= 0) {
+      stop("Conversion not implemented for ", stat_type)
+    }
+    pos <- capture.output(p$layers[[layer.i]]$position)
+    if (length(grep("identity", pos)) > 0) {
+      layout$barmode <- "overlay"
+    } else if (length(grep("stack", pos)) > 0) {
+      layout$barmode <- "stack"
     }
   }
+  
   ## Extract data from built ggplots
   built <- ggplot2::ggplot_build(p)
   ranges <- built$panel$ranges[[1]]


### PR DESCRIPTION
- Took this chunk of code outside the for loop, since plotly does not handle barmode at the layer/trace level anyway.
- Added an error message since `geom_bar()` is only partially supported. Default is `geom_bar(..., stat="bin")` and our current implementation is for `geom_bar(..., stat="identity")`!
  I tend to draw inspiration from the Plotly gallery more than from examples in the ggplot2 docs.
