### PR TITLE
Give `showlegend` boolean value directly

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -574,7 +574,7 @@ gg2list <- function(p){
     }
   
   ## Remove legend if theme has no legend position
-  if(theme.pars$legend.position=="none") layout$showlegend <- FALSE
+  layout$showlegend <- !(theme.pars$legend.position=="none")
   
   ## Main plot title.
   layout$title <- built$plot$labels$title


### PR DESCRIPTION
The default is to show the legend.

This change does not affect the plots.
As of now, this change affects the JSON and the return of `get_figure()`, which now have `layout$showlegend` equal to `TRUE` when previously unspecified.  But this is the intended default anyway.
