### PR TITLE
Enables proxy support

### DIFF
--- a/R/plotly.R
+++ b/R/plotly.R
@@ -84,13 +84,16 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
     if (is.null(kwargs$fileopt))
       kwargs$fileopt <- NULL
     url <- paste(base.url, "/clientresp", sep="")
-    options(RCurlOptions=list(sslversion=3,
-                              cainfo=system.file("CurlSSL", "cacert.pem",
-                                                 package="RCurl")))
-    respst <- postForm(url, platform="R", version=pub$version,
+
+    respst <- postForm(url, platform="R", version=pub$version, 
                        args=toJSON(args, collapse=""), un=pub$username,
                        key=pub$key, origin=origin,
-                       kwargs=toJSON(kwargs, collapse=""))
+                       kwargs=toJSON(kwargs, collapse=""),
+                       .opts=list(sslversion=3, cainfo=system.file("CurlSSL", "cacert.pem", package="RCurl")))
+    if (is.raw(respst)) {
+        respst <- rawToChar(respst)
+    }
+
     resp <- fromJSON(respst, simplify = FALSE)
     if (!is.null(resp$filename))
       pub$filename <- resp$filename


### PR DESCRIPTION
2 updates:

1) Modified `pub$makecall` so that it no longer overwrites global RCurlOptions. This is necessary to respect any proxy settings the user may have defined. 
2) `postForm` may return a raw vector, which causes the subsequent call to `fromJSON` to choke, so I've added a line to convert its return value to character, if it comes back as raw.
