### PR TITLE
Let user control display/embed behaviour more explicitly

### DIFF
--- a/R/plotly.R
+++ b/R/plotly.R
@@ -140,14 +140,14 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
         browseURL(resp$url)
       }
       invisible(list(data=pargs, response=resp))
-    } else if (session == "ipynb") {  # we are in the IR notebook
+    } else if (session == "notebook") {  # we are in the IR notebook
       do.call(pub$irplot, pargs)
       invisible(list(data=pargs))
     } else if (session == "knitr") {  # we are in knitr/RStudio
       do.call(pub$iplot, pargs)
       invisible(list(data=pargs))
     } else {
-      stop("Value of session can be: 'interactive', 'ipynb', or 'knitr'.")
+      stop("Value of session can be: 'interactive', 'notebook', or 'knitr'.")
     }
   }
   pub$get_figure <- function(file_owner, file_id) {


### PR DESCRIPTION
For lack of a better approach, I decided to handle the different ways of displaying/embedding plotly graphs (depending on session mode) with a parameter for the `ggplotly()` method.  This parameter, `session`, can take 3 possible values: `interactive` (default, reminiscent of former implementation), 'knitr' and 'ipynb' (which stands for IPython Notebook, running a native R kernel).
Defaulting to this behaviour has proven useful in the Shiny App use case (where session was not detected as interactive, as expected).
Please review /cc @pedrodz @xsaintmleux @tdhock 
Documenting ipynb use right away.
