### PR TITLE
Add direct link to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Learn More
 Stay in touch
 ---
 - <feedback@plot.ly>
-- [@plotlygraphs](twitter.com/plotlygraphs)
+- [@plotlygraphs](https://twitter.com/plotlygraphs)
 
 
 ---


### PR DESCRIPTION
Since https://plot.ly/ggplot2/ is already under large "Get Started".
