### PR TITLE
ggplot: Beautify Labels in Facets

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -615,7 +615,7 @@ gg2list <- function(p){
               text <- paste(lapply(gglayout[gglayout$ROW == i, frows, drop=FALSE][1,],
                                    as.character),
                             collapse=", ")
-              if (text!="") {  # to not create extra annotations
+              if (text != "") {  # to not create extra annotations
                 increase_margin_r <- TRUE
                 annotations[[nann]] <- make.label(text,
                                                   1 + outer.margin - 0.04,


### PR DESCRIPTION
Fixing particular cases when faceting:
- Space and alignment for plots using facet_wrap(). https://plot.ly/~pdespouy/491 vs https://plot.ly/~pdespouy/595
- Clean "new text" annotations. https://plot.ly/~pdespouy/490 vs https://plot.ly/~pdespouy/594
- Angles on yaxis label. https://plot.ly/~pdespouy/491 vs https://plot.ly/~pdespouy/678
- Alignment and spacing on the yaxis, using facet_grid(). https://plot.ly/~pdespouy/641 vs https://plot.ly/~pdespouy/795
- Alignment for yxis title. https://plot.ly/~pdespouy/491 vs https://plot.ly/~pdespouy/836

/cc @mkcor @xsaintmleux 
