### PR TITLE
ggplot: Beautify Labels in Facets, xanchor

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -676,7 +676,7 @@ gg2list <- function(p){
       annotations[[nann]] <- make.label(yaxis.title, 
                                         -outer.margin, 
                                         0.5,
-                                        textangle=-90")
+                                        textangle=-90)
       nann <- nann + 1
       
       layout$annotations <- annotations


### PR DESCRIPTION
- Add xanchor="center" for yaxis labels, using facet_grid() and facet_wrap()

/cct thank you @xsaintmleux @mkcor 
