### PR TITLE
Convert violin plot as boxplot for now

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -145,7 +145,8 @@ toBasic <- list(
   },
   path=function(g){
     group2NA(g, "path")
-  },line=function(g){
+  },
+  line=function(g){
     g$data <- g$data[order(g$data$x),]
     group2NA(g, "path")
   },
@@ -743,6 +744,13 @@ layer2traces <- function(l, d, misc) {
             prestats.data=misc$prestats.data)
   ## needed for when group, etc. is an expression.
   g$aes <- sapply(l$mapping, function(k) as.character(as.expression(k)))
+  
+  # Partial conversion for geom_violin (Plotly does not offer KDE yet)
+  if (g$geom == "violin") {
+    g$geom <- "boxplot"
+    warning("Converting violin plot into boxplot:\n
+            probability density estimation is not supported in Plotly yet.")
+  }
 
   ## Barmode.
   barmode <- "group"

--- a/tests/testthat/test-ggplot-boxplot.R
+++ b/tests/testthat/test-ggplot-boxplot.R
@@ -13,3 +13,17 @@ test_that("geom_boxplot gives a boxplot", {
   expect_identical(sort(L[[1]]$y),
                    sort(mtcars$mpg[mtcars$cyl == 4]))
 })
+
+test_that("geom_violin is equated to geom_boxplot for now", {
+  gg <- ggplot(mtcars, aes(factor(cyl), mpg)) + geom_violin()
+  
+  L <- gg2list(gg)
+  
+  # right nb. traces
+  expect_equal(length(L), 4)
+  # right type for 1st trace
+  expect_identical(L[[1]]$type, "box")
+  # right data for 1st trace
+  expect_identical(sort(L[[1]]$y),
+                   sort(mtcars$mpg[mtcars$cyl == 4]))
+})


### PR DESCRIPTION
A violin plot is a combination of a box plot and a kernel density plot (Wikipedia).

Convert the box plot part for now, so that calling `ggplotly()` on a violin plot does not return an error, but just a warning.

As kernel density estimations (KDE) become available in Plotly, we will support more faithful conversions.

/cc @xsaintmleux @pedrodz @chriddyp 
