### PR TITLE
ggplot: geom_ribbon()

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -173,9 +173,6 @@ toBasic <- list(
     g$params$xstart <- min(g$prestats.data$globxmin)
     g$params$xend <- max(g$prestats.data$globxmax)
     g
-  },
-  ribbon=function(g){
-    stop("TODO")
   }
 )
 
@@ -325,6 +322,12 @@ geom2trace <- list(
          name=params$name,
          type="scatter",
          fill="tozeroy")
+  },
+  ribbon=function(data, params) {
+    list(x=c(data$x[1], data$x, rev(data$x)),
+         y=c(data$ymin[1], data$ymax, rev(data$ymin)),
+         type="scatter",
+         fill="tonexty")
   },
   abline=function(data, params) {
     list(x=c(params$xstart, params$xend),

--- a/tests/testthat/test-ggplot-ribbon.R
+++ b/tests/testthat/test-ggplot-ribbon.R
@@ -1,0 +1,13 @@
+context("ribbon")
+
+huron <- data.frame(year=1875:1972, level=as.vector(LakeHuron))
+
+rb <- ggplot(huron, aes(x=year)) + geom_ribbon(aes(ymin=level-1, ymax=level+1))
+L <- gg2list(rb)
+
+test_that("sanity check for geom_ribbon", {
+  expect_equal(length(L), 2)
+  expect_identical(L[[1]]$type, "scatter")
+  expect_equal(L[[1]]$x, c(huron$year[1], huron$year, rev(huron$year)))
+  expect_equal(L[[1]]$y, c(huron$level[1]-1, huron$level+1, rev(huron$level-1)))
+})


### PR DESCRIPTION
Basic implementation of geom_ribbon()

Example, running this line of code: 
gg <- ggplot(huron, aes(x=year)) + geom_ribbon(aes(ymin=level-1, ymax=level+1))
outputs: https://plot.ly/~pdespouy/1262

Particular case of NAs in data: to be implemented.

//cc @mkcor 
