### PR TITLE
ggplot: geom_point: size

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -353,8 +353,8 @@ aes2line <- c(linetype="dash",
 
 markLegends <-
   ## NOTE: Do we also want to split on size?
-  ## Legends based on sizes not implemented yet in plotly
-##  list(point=c("colour", "fill", "shape", "size"),
+  ## Legends based on sizes not implemented yet in Plotly
+  ##  list(point=c("colour", "fill", "shape", "size"),
   list(point=c("colour", "fill", "shape"),
        path=c("linetype", "size", "colour"),
        polygon=c("colour", "fill", "linetype", "size", "group"),


### PR DESCRIPTION
When using size, ggplot changes circle sizes relatively using a range of 1-6. https://github.com/hadley/ggplot2/blob/4bb9270ef4d5d5062353438fd99d17b6f6de98a2/R/scale-size.r

The mathematical conversion was based on this post: http://stackoverflow.com/questions/929103/convert-a-number-range-to-another-range-maintaining-ratio

The minimum range in ggplot (1) is equivalent to the width of a grid line. For plotly, this is 0.25. As to keep the original difference (6 - 1 = 5), we use (5.25 - 0.25 = 5)

This translation is not perfect, because in addition ggplot sizes the markers line width in terms of size of circles - Plotly only uses one value for all makers lines width. https://github.com/hadley/ggplot2/blob/4bb9270ef4d5d5062353438fd99d17b6f6de98a2/R/scale-size.r#L53-L55

Examples using these changes:
map: https://plot.ly/~pdespouy/1325/lat-vs-long/
sepal&petal: https://plot.ly/~pdespouy/1324/sepalwidth-vs-petalwidth/
mpg&wt: https://plot.ly/~pdespouy/1329/mpg-vs-wt/
