### PR TITLE
Fix combination of size and colour in geom_point

### DIFF
--- a/tests/testthat/test-ggplot-size.R
+++ b/tests/testthat/test-ggplot-size.R
@@ -1,6 +1,6 @@
 context("size")
 
-test_that("size is not a vector if it is not specified",{
+test_that("size is not a vector if it is not specified", {
   iplot <- ggplot(iris)+
     geom_point(aes(Petal.Width, Sepal.Width))
   L <- gg2list(iplot)
@@ -9,11 +9,26 @@ test_that("size is not a vector if it is not specified",{
   expect_true(length(m$size) <= 1)
 })
 
-test_that("size is a vector if it is specified",{
+test_that("size is a vector if it is specified", {
   iplot <- ggplot(iris)+
     geom_point(aes(Petal.Width, Sepal.Width, size=Petal.Length))
   L <- gg2list(iplot)
   m <- L[[1]]$marker
   expect_that(m, is_a("list"))
   expect_true(length(m$size) > 1)
+})
+
+countrypop <- data.frame(country=c("Paraguay", "Peru", "Philippines"),
+                         population=c(7, 31, 101),
+                         edu=c(4.2, 1.75, 1.33),
+                         illn=c(0.38, 1.67, 0.43))
+
+gg <- ggplot(countrypop, aes(edu, illn, colour=country, size=population)) +
+  geom_point()
+
+test_that("global scaling works for sizes over different traces", {
+  L <- gg2list(gg)
+  expect_equal(length(L), 4)  # 1 trace per country (3) + layout
+  expect_true(as.numeric(L[[1]]$marker$size) < as.numeric(L[[2]]$marker$size))
+  expect_true(as.numeric(L[[2]]$marker$size) < as.numeric(L[[3]]$marker$size))
 })


### PR DESCRIPTION
So far, `size` was handled over one trace (PR #108 for reference).
One layer in ggplot2 can correspond to multiple traces in plotly, typically when you make use of the `colour` aesthetics (see additional example in `test-ggplot-size.R`).
I applied the same idea as I once did for the x-range: You want to keep the global range (as opposed to per-trace) and scale accordingly within each trace.
/cc @pedrodz 
