### PR TITLE
ggplot: themes: element_blank() for grid

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -565,6 +565,7 @@ gg2list <- function(p){
     s <- function(tmp)sprintf(tmp, xy)
     ax.list$tickcolor <- toRGB(theme.pars$axis.ticks$colour)
     ax.list$gridcolor <- toRGB(theme.pars$panel.grid.major$colour)
+    ax.list$showgrid <- !is.blank(s("panel.grid.major.%s"))
     ## These numeric length variables are not easily convertible.
     ##ax.list$gridwidth <- as.numeric(theme.pars$panel.grid.major$size)
     ##ax.list$ticklen <- as.numeric(theme.pars$axis.ticks.length)


### PR DESCRIPTION
Translating element_blank() when used with grids in theme function.

Examples:
z <- z + theme(panel.grid.major =  element_blank()): https://plot.ly/~pdespouy/1489/mpg-vs-wt/
z <- z + theme(panel.grid.major.x = element_blank()): https://plot.ly/~pdespouy/1488/mpg-vs-wt/
z <- z + theme(panel.grid.major.y = element_blank()): https://plot.ly/~pdespouy/1487/mpg-vs-wt/

/cc @mkcor 
