### PR TITLE
ggplot: using bg colors in theme(rect=...)

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -576,6 +576,7 @@ gg2list <- function(p){
     ax.list$tickangle <- if(is.numeric(tick.text$angle)){
       -tick.text$angle
     }
+    
     theme2font <- function(text){
       if(!is.null(text)){
         list(family=text$family,
@@ -835,6 +836,17 @@ gg2list <- function(p){
                                                  "</b></i>")
       }
     }
+  }
+
+  # If background elements are NULL, and background rect (rectangle) is defined:
+  rect_fill <- theme.pars$rect$fill
+  if (!is.null(rect_fill)) {
+    if (is.null(layout$plot_bgcolor))
+      layout$plot_bgcolor <- toRGB(s(rect_fill))
+    if (is.null(layout$paper_bgcolor))
+      layout$paper_bgcolor <- toRGB(s(rect_fill))
+    if (is.null(layout$legend$bgcolor))
+      layout$legend$bgcolor <- toRGB(s(rect_fill))
   }
   
   trace.list$kwargs <- list(layout=layout)


### PR DESCRIPTION
Implementing use of background colors in `theme(rect=...)`.

When using `rect`, values are assigned to all rectangle elements in ggplot2, i.e., `legend`, `panel`, and `plot`.

Example:

```
library(ggthemes)
sampledat <- diamonds[sample(nrow(diamonds), 500),]
p <- ggplot(data = sampledat, aes(carat, price, colour = cut)) + geom_point(size = 5, alpha = 0.5) +
  labs(title = "Scatter Plot Example", x = "Carat", y = "Price", colour = "Cut") 
p <- p + theme_wsj()
```

yields https://plot.ly/~pdespouy/1520/scatter-plot-example/

cc/ @mkcor 
