### PR TITLE
ggplot: themes: dashed and dotted grid lines

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -1167,14 +1167,14 @@ paramORdefault <- function(params, aesVec, defaults){
 #' @param alpha alpha
 #' @return hexadecimal color value (if is.na(x), return "none" for compatibility with JavaScript)
 #' @export
-toRGB <- function(x, alpha = 1){
+toRGB <- function(x, alpha=1) {
   if(is.null(x))return(x)
   if (alpha!=1) {
     rgb.matrix <- col2rgb(x, TRUE)
     rgb.matrix["alpha", 1] <- alpha
     ch.vector <- "rgba(%s)"
   } else {
-    rgb.matrix <- col2rgb(x, FALSE)
+    rgb.matrix <- col2rgb(x)
     ch.vector <- "rgb(%s)"
   }
   rgb.text <- apply(rgb.matrix, 2, paste, collapse=",")

--- a/man/toRGB.Rd
+++ b/man/toRGB.Rd
@@ -6,9 +6,9 @@
 toRGB(x, alpha = 1)
 }
 \arguments{
-\item{x}{character}
+\item{x}{character for color, for example: "white"}
 
-\item{alpha}{integer}
+\item{alpha}{alpha}
 }
 \value{
 hexadecimal color value (if is.na(x), return "none" for compatibility with JavaScript)

--- a/tests/testthat/test-ggplot-theme.R
+++ b/tests/testthat/test-ggplot-theme.R
@@ -28,6 +28,7 @@ test_that("dotted/dashed grid translated as line with alpha=0.1",{
   for (xy in c("x", "y")) {
     ax.list <- info$kwargs$layout[[paste0(xy, "axis")]]
     expect_identical(ax.list$gridcolor, toRGB("white", 0.1))
+    expect_identical(ax.list$gridcolor, "rgba(255,255,255,0.1)")
   }
 })
 


### PR DESCRIPTION
ggplot: themes: dashed and dotted grid lines as lines with alpha=0.1
- Temporary solution until `dashed` and `dotted` grid lines are implemented in Plotly.
- `toRGB()` function was modified as to accept alpha values.
- Styling was done in the `test-ggplot-theme.R` script.

Example: https://plot.ly/~pdespouy/1573/scatter-plot-example/

cc/ @mkcor 
