### PR TITLE
ggplot: scatterplot: hollow circles, symbol mappings, marker style

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -74,8 +74,7 @@ aes2marker <- c(alpha="opacity",
                 size="size",
                 sizeref="sizeref",
                 sizemode="sizemode",
-                shape="symbol")#,
-                #fill="color")
+                shape="symbol")
 
 default.marker.sizeref <- 1
 marker.size.mult <- 10
@@ -253,15 +252,13 @@ geom2trace <- list(
       L$marker$size <- if (length(s) > 1) marker.size else list(marker.size)
       L$marker$line$width <- 0
     } 
-    print(data)
-    print(params)
-    if (params$shape %in% c(21:25)) {
+    if (!is.null(params$shape) && params$shape %in% c(21:25)) {
       L$marker$color <- ifelse(!is.null(params$fill), toRGB(params$fill), "rgba(0,0,0,0)")
       if (!is.null(params$colour))
         L$marker$line$color <- toRGB(params$colour)
       L$marker$line$width <- 1
     }
-    if (params$shape %in% c(32)) {
+    if (!is.null(params$shape) && params$shape %in% c(32)) {
       L$visible <- FALSE
     }
     L


### PR DESCRIPTION
ggplot: scatterplot: hollow cicles
- `shape=1` in ggplot is `circle-open` in Plotly

Example: 

```
sampledat <- diamonds[sample(nrow(diamonds), 500), ]
p <- ggplot(data = sampledat, aes(carat, price, colour = cut)) + 
  geom_point(size = 5, alpha = 0.5, shape = 1) +
  labs(title = "Scatter Plot Example", x = "Carat", y = "Price", colour = "Cut") 
```

https://plot.ly/~pdespouy/1593/scatter-plot-example/

cc/ @mkcor @chriddyp 
