### PR TITLE
ggplot: themes: fix marker default shape

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -6,7 +6,7 @@ default.marker.sizeref <- 1
 marker.size.mult <- 10
 
 marker.defaults <- list(alpha=1,
-                        shape="o",
+                        shape="16",
                         size=marker.size.mult,
                         sizeref=default.marker.sizeref,
                         sizemode="area",

--- a/tests/testthat/test-ggplot-theme.R
+++ b/tests/testthat/test-ggplot-theme.R
@@ -32,6 +32,20 @@ test_that("dotted/dashed grid translated as line with alpha=0.1",{
   }
 })
 
+countrypop <- data.frame(country=c("Paraguay", "Peru", "Philippines"),
+                         population=c(7, 31, 101),
+                         edu=c(4.2, 1.75, 1.33),
+                         illn=c(0.38, 1.67, 0.43))
+gg <- ggplot(countrypop) +
+  geom_point(aes(edu, illn, colour=country, size=population))
+
+test_that("marker default shape is a circle", {
+  info <- gg2list(gg)
+  for (i in c(1:3)) {
+    expect_identical(info[[i]]$marker$symbol, "circle")
+  }
+})
+
 test_that("plot panel border is translated correctly", {
   ggiris <- iris.base + theme_grey() # has no panel.border
   info <- gg2list(ggiris)


### PR DESCRIPTION
ggplot: themes: fix marker default shape

By changing `shape="o"` from `circle` to `circle-open`, #114 changed default marker shape... Thanks to @mkcor for finding this.
- Change marker default shape to 16
- Add a test

Before PR: https://plot.ly/~pdespouy/1730/illn-vs-edu/;
After PR: https://plot.ly/~pdespouy/1731/illn-vs-edu/

cc/ @mkcor @chriddyp 
