### PR TITLE
R API: Change SSLv3 to TLSv1

### DIFF
--- a/R/plotly.R
+++ b/R/plotly.R
@@ -96,11 +96,14 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
                        args=toJSON(args, digits=50, collapse=""), un=pub$username,
                        key=pub$key, origin=origin,
                        kwargs=toJSON(kwargs, digits=50, collapse=""),
-                       .opts=list(sslversion=3, cainfo=system.file("CurlSSL", "cacert.pem", package="RCurl")))
+                       .opts=list(sslversion=1,  # 1 is for TLSv1
+                                  cainfo=system.file("CurlSSL",
+                                                     "cacert.pem",
+                                                     package="RCurl")))
     if (is.raw(respst)) {
         respst <- rawToChar(respst)
     }
-
+    
     resp <- fromJSON(respst, simplify = FALSE)
     if (!is.null(resp$filename))
       pub$filename <- resp$filename


### PR DESCRIPTION
Yesterday, for security reasons SSLv3 got deprecated. Message returned from running `py$ggplotly()`:

```
Error in function (type, msg, asError = TRUE)  :
  Unknown SSL protocol error in connection to plot.ly:-9824
```

Protocol is changed from SSLv3 to TLSv1. `sslversion=1` is for TLSv1, see http://stackoverflow.com/questions/17119449/rcurl-boolean-options. It can me checked with:

```
c(RCurl:::SSLVERSION_TLSv1, RCurl:::SSLVERSION_SSLv3)
```

cc/ @mkcor 
