### PR TITLE
Increment version number after many changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plotly
 Type: Package
 Title: Interactive, publication-quality graphs online.
-Version: 0.4
+Version: 0.5.0
 Authors@R: c(person("Chris", "Parmer", role = c("aut", "cre"),
     email = "chris@plot.ly"),
     person("Scott", "Chamberlain", role = "aut",
@@ -9,7 +9,11 @@ Authors@R: c(person("Chris", "Parmer", role = c("aut", "cre"),
     person("Karthik", "Ram", role = "aut",
     email = "karthik.ram@gmail.com"),
     person("Toby", "Hocking", role="aut",
-    email="tdhock5@gmail.com"))
+    email="tdhock5@gmail.com"),
+    person("Marianne", "Corvellec", role="aut",
+    email="marianne@plot.ly"),
+    person("Pedro", "Despouy", role="aut",
+    email="pedro@plot.ly"))
 Author: Chris Parmer
 Maintainer: Marianne Corvellec <marianne@plot.ly>
 License: MIT + file LICENSE

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -82,7 +82,7 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
   
   # public attributes/methods that the user has access to
   pub <- list(username=username, key=key, filename="from api", fileopt=NULL,
-              version="0.4.0")
+              version="0.5.0")
   priv <- list()
   
   pub$makecall <- function(args, kwargs, origin) {


### PR DESCRIPTION
Let's use the following standard version numbering scheme: major.minor.revision
Typically, "the major number is increased when there are significant jumps in functionality, the minor number is incremented when only minor features or significant fixes have been added, and the revision number is incremented when minor bugs are fixed" (see http://en.wikipedia.org/wiki/Software_versioning).

Changes since version "0.4" include using a newer encryption protocol (just now), supporting many more geom's (see #18) and many more theme-related features (better conversion of ticks, labels, grid lines, etc.)

/cc @pedrodz @chriddyp 
