### PR TITLE
ggplot: legend: Improve title position

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -496,7 +496,7 @@ gg2list <- function(p){
     layout$margin$r <- 60
   }
   layout$legend <- list(bordercolor="transparent", 
-                        x=1.04, y=1/2,
+                        x=1.05, y=1/2,
                         xanchor="center", yanchor="top")
   
   # Workaround for removing unnecessary legends.


### PR DESCRIPTION
This PR is to tackle https://github.com/ropensci/plotly/pull/142#issuecomment-62310471

Summary:
- Legend: `xanchor=center`, `yanchor=top`
- Legend title (annotation): `xanchor=center`

With `xanchor` `center`, legend was on top of plot. Legend `x` position (unfortunately) had to be hard-coded to `1.04`. If `x` position is not hard-coded: https://plot.ly/~pdespouy/2211/total-bill-vs-time/
With large number of variables, legend skews to the bottom, see https://plot.ly/~pdespouy/2209/posttest-vs-pretest/

Examples:

With 2 variables un-merged, before PR: https://plot.ly/~pdespouy/2203/total-bill-vs-time/
With 2 variables un-merged, after PR: https://plot.ly/~pdespouy/2207/total-bill-vs-time/

With 2 variables, before PR: https://plot.ly/~pdespouy/2204/rating-vs-cond/
With 2 variables, after PR: https://plot.ly/~pdespouy/2208/rating-vs-cond/

With 9 variables, before PR: https://plot.ly/~pdespouy/2205/posttest-vs-pretest/
With 9 variables, after PR: https://plot.ly/~pdespouy/2209/posttest-vs-pretest/

With 3 variables, before PR: https://plot.ly/~pdespouy/2206/weight-vs-group/
With 3 variables, after PR: https://plot.ly/~pdespouy/2210/weight-vs-group/
