### PR TITLE
Add 'plotly_selecting' to acceptable 'on' events

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New features
 
 * `ggplotly()` now supports the `{ggalluvial}` package. (#2061, thanks @moutikabdessabour)
+* `highlight()` now supports `on="plotly_selecting"`, enabling client-side linked brushing via mouse click+drag (no mouse-up event required, as with `on="plotly_selected"`). (#1280)
 
 ## Bug fixes
 

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -130,6 +130,7 @@ highlight <- function(p, on = "plotly_click", off,
   if (missing(off)) {
     off_default <- switch(
       on %||% "", 
+      plotly_selecting = ,
       plotly_selected = "plotly_deselect",
       plotly_click = "plotly_doubleclick",
       plotly_hover = "plotly_doubleclick"
@@ -148,7 +149,7 @@ highlight <- function(p, on = "plotly_click", off,
   # main (non-plotly.js) spec passed along to HTMLwidgets.renderValue()
   p$x$highlight <- list(
     # NULL may be used to disable on/off events
-    on = if (!is.null(on)) match.arg(on, paste0("plotly_", c("click", "hover", "selected"))),
+    on = if (!is.null(on)) match.arg(on, paste0("plotly_", c("click", "hover", "selected", "selecting"))),
     off = if (is.default(off)) off else if (!is.null(off)) match.arg(off, off_options),
     persistent = persistent,
     dynamic = dynamic,

--- a/R/utils.R
+++ b/R/utils.R
@@ -401,7 +401,7 @@ supply_highlight_attrs <- function(p) {
   # add HTML dependencies, set a sensible dragmode default, & throw messages
   if (hasKeys) {
     p$x$layout$dragmode <- p$x$layout$dragmode %|D|% 
-      default(switch(p$x$highlight$on %||% "", plotly_selected = "select") %||% "zoom")
+      default(switch(p$x$highlight$on %||% "", plotly_selected = "select", plotly_selecting = "select") %||% "zoom")
     if (is.default(p$x$highlight$off)) {
       message(
         sprintf(

--- a/demo/crosstalk-highlight-intro.R
+++ b/demo/crosstalk-highlight-intro.R
@@ -27,15 +27,14 @@ layout(p, title = "Click on a marker to highlight that patient")
 # "plotly_selected", which corresponds to click and drag mouse events.
 p %>%
   layout(title = "Click and drag to select patient") %>%
-  highlight("plotly_selected")
-
+  highlight("plotly_selecting")
 
 # Plotly provides two types of drag modes that will trigger a "plotly_selected"
 # event: "lasso" and "select". You can change the dragmode interactively via 
 # the modebar and/or set the default dragmode via `layout()`.
 p %>%
   layout(title = "Click and drag to select patient", dragmode = "lasso") %>%
-  highlight("plotly_selected")
+  highlight("plotly_selecting")
 
 # The first argument of `highlight()`, `on`, sets the interaction type used 
 # trigger a "highlight selection". The second argument, `off`, sets the 


### PR DESCRIPTION
Seems plotly.js isn't (yet) able to support data-level modifications of a plot during `plotly_selecting`, but there is [there is hope](https://github.com/plotly/plotly.js/issues/2644#issuecomment-391152782) that one day it'll be a non-issue (so this PR will wait until https://github.com/plotly/plotly.js/issues/2687 is resolved)

More reading:

https://community.plot.ly/t/adding-traces-during-plotly-selecting/10679
https://github.com/plotly/plotly.js/issues/2644
https://github.com/plotly/plotly.js/issues/2687
https://github.com/plotly/plotly.js/issues/2643