### PR TITLE
Access persistent click/hover data in shiny, addresses #1401

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -277,29 +277,71 @@ HTMLWidgets.widget({
         );
       });
       graphDiv.on('plotly_hover', function(d) {
+        
         Shiny.onInputChange(
           ".clientValue-plotly_hover-" + x.source, 
           JSON.stringify(eventDataWithKey(d))
         );
-      });
-      graphDiv.on('plotly_click', function(d) {
+        
+        // When persistent selection is enabled (either through
+        // shift or highlight()), remember click data
+        if (x.highlight.persistentShift) {
+          var dShift = graphDiv._shiny_plotly_hover || {points: []};
+          var pts = [].concat(dShift.points, d.points);
+          var d = {points: pts, event: d.event};
+          graphDiv._shiny_plotly_hover = d;
+        } else {
+          graphDiv._shiny_plotly_hover = undefined;
+        }
+        
         Shiny.onInputChange(
-          ".clientValue-plotly_click-" + x.source, 
+          ".clientValue-plotly_hover_persist_on_shift-" + x.source,
           JSON.stringify(eventDataWithKey(d))
         );
+        
       });
+      graphDiv.on('plotly_click', function(d) {
+        
+        Shiny.onInputChange(
+          ".clientValue-plotly_click-" + x.source,
+          JSON.stringify(eventDataWithKey(d))
+        );
+        
+        // When persistent selection is enabled (either through
+        // shift or highlight()), remember click data
+        if (x.highlight.persistentShift) {
+          var dShift = graphDiv._shiny_plotly_click || {points: []};
+          var pts = [].concat(dShift.points, d.points);
+          var d = {points: pts, event: d.event};
+          graphDiv._shiny_plotly_click = d;
+        } else {
+          graphDiv._shiny_plotly_click = undefined;
+        }
+        
+        Shiny.onInputChange(
+          ".clientValue-plotly_click_persist_on_shift-" + x.source,
+          JSON.stringify(eventDataWithKey(d))
+        );
+        
+      });
+      
       graphDiv.on('plotly_selected', function(d) {
         Shiny.onInputChange(
           ".clientValue-plotly_selected-" + x.source, 
           JSON.stringify(eventDataWithKey(d))
         );
       });
+      
       graphDiv.on('plotly_unhover', function(eventData) {
-        Shiny.onInputChange(".clientValue-plotly_hover-" + x.source, null);
+        if (!x.highlight.persistentShift) {
+          Shiny.onInputChange(".clientValue-plotly_hover-" + x.source, null);
+        }
       });
+      
       graphDiv.on('plotly_doubleclick', function(eventData) {
         Shiny.onInputChange(".clientValue-plotly_click-" + x.source, null);
       });
+      
       // 'plotly_deselect' is code for doubleclick when in select mode
       graphDiv.on('plotly_deselect', function(eventData) {
         Shiny.onInputChange(".clientValue-plotly_selected-" + x.source, null);


### PR DESCRIPTION
See #1401 for more context

## Review questions

  - [ ] Is it safe to remember event data by attaching an attribute to `graphDiv` in this way? Should try this out in conjunction with `plotlyProxy()`.
  - [ ] Should we worry about emitting redundant data in the persistent case? Or should this be the responsibility of the user?
  - [ ] Should we worry that the persistent hover data isn't cleared when unhovering after a shift?

## Testing notes

Install (`devtools::install_github("ropensci/plotly#1409")`), run this app, and make sure the event data is what you'd expect.

```r
library(shiny)
library(plotly)

ui <- fluidPage(
  plotlyOutput("plot"),
  verbatimTextOutput("click"),
  verbatimTextOutput("shift_click"),
  verbatimTextOutput("hover"),
  verbatimTextOutput("shift_hover")
)

server <- function(input, output, session) {
  output$plot <- renderPlotly({
    plot_ly(x = 1:10, y = 1:10, key = LETTERS[1:10])
  })
  
  output$click <- renderPrint({
    d <- event_data("plotly_click")
    if (is.null(d)) "Transient click data" else d
  })
  output$shift_click <- renderPrint({
    d <- event_data("plotly_click_persist_on_shift")
    if (is.null(d)) "Persistent click data" else d
  })
  output$hover <- renderPrint({
    d <- event_data("plotly_hover")
    if (is.null(d)) "Transient hover data" else d
  })
  output$shift_hover <- renderPrint({
    d <- event_data("plotly_hover_persist_on_shift")
    if (is.null(d)) "Persistent hover data" else d
  })
}

shinyApp(ui, server)
```