### PR TITLE
Prevent RColorBrewer::brewer.pal warning

### DIFF
--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -785,7 +785,7 @@ map_color <- function(traces, stroke = FALSE, title = "", colorway, na.color = "
     isOrdered <- all(vapply(color[isDiscrete], is.ordered, logical(1)))
     lvls <- getLevels(unlist(color[isDiscrete]))
     N <- length(lvls)
-    pal <- palette %||% if (isOrdered) viridisLite::viridis(N) else RColorBrewer::brewer.pal(N, "Set2")
+    pal <- palette %||% if (isOrdered) viridisLite::viridis(N) else RColorBrewer::brewer.pal(max(N, 3L), "Set2")
     colScale <- scales::col_factor(pal, levels = names(pal) %||% lvls, na.color = na.color)
     color_codes <- Map(function(x, y) toRGB(colScale(as.character(x)), y), color[isDiscrete], alphas[isDiscrete])
     traces[isDiscrete] <- Map(mapColor, traces[isDiscrete], color_codes)


### PR DESCRIPTION
`RColorBrewer::brewer.pal()` throws an (in this case) unnecessary warning if the output plot requires less than 2 colors. This is an easy fix, and does not change the workings of the code since `RColorBrewer::brewer.pal()` never returns less than three levels anywas:

```
> RColorBrewer::brewer.pal(2, "Set2")
[1] "#66C2A5" "#FC8D62" "#8DA0CB"
Warning message:
In RColorBrewer::brewer.pal(2, "Set2") :
  minimal value for n is 3, returning requested palette with 3 different levels
```