### PR TITLE
Allowed for user defined axis positions. Closes #2029

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -753,6 +753,7 @@ gg2list <- function(p, width = NULL, height = NULL,
         gridwidth = unitConvert(panelGrid, "pixels", type),
         zeroline = FALSE,
         anchor = anchor,
+        side = scales$get_scales(xy)$position,
         # layout.axisid.title don't yet support alignment :(
         title = list(
           text = faced(axisTitleText, axisTitle$face),


### PR DESCRIPTION
Now the user can define the axis positions directly from `ggplot`.
```r
library(plotly)
library(ggplot2)

p <- ggplot(mtcars) +
  geom_point(aes(disp, mpg)) +
  scale_x_continuous(position = 'top')

ggplotly(p)
```
![Screen Shot 2021-10-08 at 9 05 15 AM](https://user-images.githubusercontent.com/11250014/136588627-864c33b0-c0d6-4799-8c57-2dfe11693d86.png)

the `side` child element of `axisObj` was not being set making plotly use the defaults. I added the entry and used ggplot's `get_scales` function to get the scale for each axis then the position. @cpsievert can you please approve this PR? the tests that failed are related to a missing api key