### PR TITLE
plotly.js fix bug when crosstalk filter keys are null

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * `ggplotly()` now correctly handles `geom_tile()` with no `fill` aesthetic. (#2063)
 * `ggplotly()` now respects `guide(aes = "none")` (e.g., `guide(fill = "none")`) when constructing legend entries. (#2067)
 * Fixed an issue with translating `GGally::ggcorr()` via `ggplotly()`. (#2012)
+* Fixed an issue where clearing a crosstalk filter would raise an error in the JS console (#2087)
 
 ## Improvements
 

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -616,9 +616,9 @@ TraceManager.prototype.updateFilter = function(group, keys) {
         traces.push(trace);
       }
     }
+    this.gd.data = traces;
   }
   
-  this.gd.data = traces;
   Plotly.redraw(this.gd);
   
   // NOTE: we purposely do _not_ restore selection(s), since on filter,


### PR DESCRIPTION
Hi, this is my first PR to this repository and I have reviewed the contributing guidelines. However I wasn't sure if it was necessary to create an issue first, or how to write tests for this change, so I'm open to suggestions.

## Why this PR?

I was having an issue using plotly with crosstalk filtering, where if all filters were cleared, the filtering would not be removed correctly and an exception would be raised in the browser console. This PR fixes that issue.

## Example

```r
library(crosstalk)
library(plotly)
library(DT)

data(iris)

shared_iris <- SharedData$new(iris)

a <- plot_ly(shared_iris, x = ~Sepal.Length, y = ~Sepal.Width) %>%
    add_markers() %>%
    highlight(on = "plotly_click", dynamic = TRUE)
b <- datatable(shared_iris)

bscols(
    list(
        filter_checkbox("species", "Species", shared_iris, ~Species)
    ),
    a, b 
)
```

### Steps to reproduce

In the webpage generated by the above code, select `setosa` under the species checkbox filter. Then unselect `setosa`

### Expected behaviour

the filtering returns to its original state

### Actual behaviour

the filtering doesn't change, and the following error appears in the console:
![image](https://user-images.githubusercontent.com/39182232/145707110-37a31f84-bbc9-4aa1-b728-35596365acf6.png)




