### PR TITLE
Fixed broken URL capturing ending quote 

### DIFF
--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -962,7 +962,7 @@ geom2trace.default <- function(data, params, p) {
     "geom_", class(data)[1], "() has yet to be implemented in plotly.\n",
     "  If you'd like to see this geom implemented,\n",
     "  Please open an issue with your example code at\n",
-    "  https://github.com/ropensci/plotly/issues"
+    "  https://github.com/ropensci/plotly/issues "
   )
   list()
 }


### PR DESCRIPTION
Updated `https://github.com/ropensci/plotly/issues”` to `https://github.com/ropensci/plotly/issues` in [R/layers2traces.R](https://github.com/plotly/plotly.R/compare/master...madprogramer:patch-1?expand=1#diff-d84657ae70a4603c9cac16bdc349d40ea3412a66e6b15da7ce5df59ab815fdcc)