### PR TITLE
Support nativeRaster objects in annotation_raster() and raster2uri()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Changes to plotly.js
 
 * This version of the R package upgrades the version of the underlying plotly.js library from v2.5.1 to v2.11.1. This includes many bug fixes and improvements. The [plotly.js release page](https://github.com/plotly/plotly.js/releases) has the full list of changes.
+* raster2uri() supports nativeRaster objects. This enables nativeRaster support for
+  the annotation_raster() geom.
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,13 @@
 ## Changes to plotly.js
 
 * This version of the R package upgrades the version of the underlying plotly.js library from v2.5.1 to v2.11.1. This includes many bug fixes and improvements. The [plotly.js release page](https://github.com/plotly/plotly.js/releases) has the full list of changes.
-* raster2uri() supports nativeRaster objects. This enables nativeRaster support for
-  the annotation_raster() geom (#2174, @zeehio).
 
 ## New features
 
 * `ggplotly()` now supports the `{ggalluvial}` package. (#2061, thanks @moutikabdessabour)
 * `highlight()` now supports `on="plotly_selecting"`, enabling client-side linked brushing via mouse click+drag (no mouse-up event required, as with `on="plotly_selected"`). (#1280)
+* `raster2uri()` supports nativeRaster objects. This enables nativeRaster support for
+  the `annotation_raster()` geom (#2174, @zeehio).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * This version of the R package upgrades the version of the underlying plotly.js library from v2.5.1 to v2.11.1. This includes many bug fixes and improvements. The [plotly.js release page](https://github.com/plotly/plotly.js/releases) has the full list of changes.
 * raster2uri() supports nativeRaster objects. This enables nativeRaster support for
-  the annotation_raster() geom.
+  the annotation_raster() geom (#2174, @zeehio).
 
 ## New features
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -219,14 +219,19 @@ plotly_empty <- function(...) {
 raster2uri <- function(r, ...) {
   try_library("png", "raster2uri")
   # should be 4 x n matrix
-  r <- grDevices::as.raster(r, ...)
-  rgbs <- col2rgb(c(r), alpha = T) / 255
-  nr <- dim(r)[1]
-  nc <- dim(r)[2]
-  reds <- matrix(rgbs[1, ], nrow = nr, ncol = nc, byrow = TRUE)
-  greens <- matrix(rgbs[2, ], nrow = nr, ncol = nc, byrow = TRUE)
-  blues <- matrix(rgbs[3, ], nrow = nr, ncol = nc, byrow = TRUE)
-  alphas <- matrix(rgbs[4, ], nrow = nr, ncol = nc, byrow = TRUE)
-  png <- array(c(reds, greens, blues, alphas), dim = c(dim(r), 4))
+  if (inherits(r, "nativeRaster")) {
+    # png::writePNG directly supports nativeRaster objects
+    png <- nr
+  } else {
+    r <- grDevices::as.raster(r, ...)
+    rgbs <- col2rgb(c(r), alpha = T) / 255
+    nr <- dim(r)[1]
+    nc <- dim(r)[2]
+    reds <- matrix(rgbs[1, ], nrow = nr, ncol = nc, byrow = TRUE)
+    greens <- matrix(rgbs[2, ], nrow = nr, ncol = nc, byrow = TRUE)
+    blues <- matrix(rgbs[3, ], nrow = nr, ncol = nc, byrow = TRUE)
+    alphas <- matrix(rgbs[4, ], nrow = nr, ncol = nc, byrow = TRUE)
+    png <- array(c(reds, greens, blues, alphas), dim = c(dim(r), 4))
+  }
   base64enc::dataURI(png::writePNG(png), mime = "image/png")
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -221,7 +221,7 @@ raster2uri <- function(r, ...) {
   # should be 4 x n matrix
   if (inherits(r, "nativeRaster")) {
     # png::writePNG directly supports nativeRaster objects
-    png <- nr
+    png <- r
   } else {
     r <- grDevices::as.raster(r, ...)
     rgbs <- col2rgb(c(r), alpha = T) / 255

--- a/tests/testthat/test-plotly-subplot.R
+++ b/tests/testthat/test-plotly-subplot.R
@@ -274,6 +274,21 @@ test_that("shape paper repositioning", {
   expect_equal(y1, c(30, 0.75))
 })
 
+test_that("raster2uri supports nativeRaster objects", {
+  skip_if_not_installed("png")
+
+  r <- as.raster(matrix(c("black", "red", "green", "blue"), ncol = 4L))
+  nr <- structure(
+    c(-16777216L, -16776961L, -16711936L, -65536L),
+    dim = c(1L, 4L),
+    class = "nativeRaster",
+    channels = 4L
+  )
+  uri_r <- raster2uri(r)
+  uri_nr <- raster2uri(nr)
+  expect_equal(uri_r, uri_nr)
+})
+
 
 test_that("image paper repositioning", {
   skip_if_not_installed("png")


### PR DESCRIPTION
`nativeRaster` objects allow for a much direct and faster rasterizing. If you want to know better about them and their performance I suggest to check the https://github.com/coolbutuseless/nara package (not on CRAN at least for now).

ggplot2 already supports nativeRaster objects through `annotation_raster()`, however `ggplotly` fails to render it due to a minor limitation in `raster2uri()`.

This small pull request:

- Adds support for nativeRaster objects in raster2uri
- Adds a corresponding unit test 
- Adds the entry to the news

I would really appreciate to see this merged, because right now rasterizing large images is a very slow process.

Thanks!
