### PR TITLE
plotlyOutput()'s width and height now default to NULL

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -23,7 +23,7 @@
 #' @name plotly-shiny
 #'
 #' @export
-plotlyOutput <- function(outputId, width = "100%", height = "400px", 
+plotlyOutput <- function(outputId, width = NULL, height = NULL, 
                          inline = FALSE, reportTheme = TRUE) {
   args <- list(
     outputId = outputId, 

--- a/inst/htmlwidgets/lib/plotlyjs/plotly-htmlwidgets.css
+++ b/inst/htmlwidgets/lib/plotlyjs/plotly-htmlwidgets.css
@@ -1,3 +1,8 @@
+.plotly.html-widget {
+  width: 100%;
+  height: 400px;
+}
+
 /*
 just here so that plotly works
 correctly with ioslides.


### PR DESCRIPTION
In anticipation of https://github.com/ramnathv/htmlwidgets/pull/437 (and https://github.com/rstudio/bslib/pull/452)