### PR TITLE
skip test on pre-3.4.0 ggplot2

### DIFF
--- a/tests/testthat/test-ggplot-blank.R
+++ b/tests/testthat/test-ggplot-blank.R
@@ -1,5 +1,6 @@
 
 test_that("geom_blank", {
+  skip_if_not_installed("ggplot2", "3.4.0")
   qp <- expect_warning(qplot(), "deprecated")
   l <- ggplotly(qp)$x
   


### PR DESCRIPTION
on earlier versions, the warning isn't issued.

we could branch the test based on the ggplot2 version, but doesn't seem worth it