### PR TITLE
Fix kaleido image export bug

### DIFF
--- a/R/kaleido.R
+++ b/R/kaleido.R
@@ -107,7 +107,7 @@ kaleido <- function(...) {
       # Write the base64 encoded string that transform() returns to disk
       # https://github.com/plotly/Kaleido/blame/master/README.md#L52
       reticulate::py_run_string(
-        sprintf("open('%s', 'wb').write(%s)", file, transform_cmd)
+        sprintf("import sys; open('%s', 'wb').write(%s)", file, transform_cmd)
       )
       
       invisible(file)


### PR DESCRIPTION
# Description of the problem

The code needs access to the Python sys module to run. Otherwise it gives a missing package error. The following code generates the error: 

```r
# Install latest development version
devtools::install_github("ropensci/plotly")

# Import libraries
library(plotly)
library(reticulate)

# Create example plot
fig <- plot_ly(midwest, x = ~percollege, color = ~state, type = "box")

# Simulate a conda environment to use Kaleido
reticulate::install_miniconda()
reticulate::conda_install('r-reticulate', 'python-kaleido')
reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly')
reticulate::use_miniconda('r-reticulate')

# Save the figure
save_image(fig,file="image.png", height=500, width=700)
```

The error is: 

```r
> save_image(fig,file="image.png", height=500, width=700)
Error in py_run_string_impl(code, local, convert) : 
  NameError: name 'sys' is not defined
```

This has been solved by importing the sys package in the Python command in the correct place, see commit. 

# Installing the bugfix

You can install the version with the bugfix and rerun the code like this:  

```r
# Reinstall latest development version which includes the bugfix
devtools::install_github("quinten-goens/plotly.R@fix/kaleido-export-bug")

# Import libraries
library(plotly)
library(reticulate)

# Create example plot
fig <- plot_ly(midwest, x = ~percollege, color = ~state, type = "box")

# Simulate a conda environment to use Kaleido
reticulate::install_miniconda()
reticulate::conda_install('r-reticulate', 'python-kaleido')
reticulate::conda_install('r-reticulate', 'plotly', channel = 'plotly')
reticulate::use_miniconda('r-reticulate')

# Save the figure
save_image(fig,file="image.png", height=500, width=700)
```

The export works now.
