### PR TITLE
Fix bug: ggplotly() no longer removes legends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * Closed #2218: `highlight(selectize = TRUE)` no longer yields an incorrect selectize.js result when there is a combination of crosstalk and non-crosstalk traces. (#2217) 
 * Closed #2208: `ggplotly()` no longer errors given a `geom_area()` with 1 or less data points (error introduced by new behavior in ggplot2 v3.4.0). (#2209)
 * Closed #2220: `ggplotly()` no longer errors on `stat_summary(geom = "crossbar")`. (#2222)
-
+* Closed #2212: `ggplotly()` no longer removes legends when setting guide properties via `guides(aes = guide_xxx(...))`.
 
 # 4.10.1
 

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -102,7 +102,10 @@ layers2traces <- function(data, prestats_data, layout, p) {
   }
   # now to the actual layer -> trace conversion
   trace.list <- list()
-  aes_no_guide <- names(vapply(p$guides, identical, logical(1), "none"))
+  
+  is_guide_none <- vapply(p$guides, identical, logical(1), "none")
+  aes_no_guide <- names(is_guide_none)[isTRUE(is_guide_none)]
+  
   for (i in seq_along(datz)) {
     d <- datz[[i]]
     # variables that produce multiple traces and deserve their own legend entries

--- a/tests/testthat/test-ggplot-legend.R
+++ b/tests/testthat/test-ggplot-legend.R
@@ -58,6 +58,48 @@ test_that("aesthetics can be discarded from legend with guide(aes = 'none')", {
   expect_doppelganger(p, "guide-aes-none")
 })
 
+test_that("legend can be manipulated via guides(aes = guide_xxx())", {
+  p <- ggplot(mtcars, aes(hp, mpg, color = factor(cyl))) +
+    geom_point() +
+    guides(color = guide_legend())
+  
+  info <- expect_doppelganger_built(gg, "mtcars-guides")
+  
+  expect_equivalent(sum(sapply(info$data, "[[", "showlegend")), 3)
+  
+  # Issue posted on Stackoverflow
+  # https://stackoverflow.com/questions/75365694/plotly-did-not-show-legend-when-converted-from-ggplot
+  data <- data.frame(
+    stringsAsFactors = FALSE,
+    Level = c("Fast","Fast","Fast","Fast",
+              "Fast","Fast","Slow","Slow","Slow",
+              "Slow","Slow","Slow"),
+    Period = c("1Year","3Month","1Year","3Month",
+               "1Year","3Month","1Year","3Month",
+               "1Year","3Month","1Year","3Month"),
+    X = c(0.002,0.002,0.1,0.1,0.9,0.9,
+          0.002,0.002,0.1,0.1,0.9,0.9),
+    Y = c(1.38,1.29,1.61,1.61,1.74,0.98,
+          1.14,0.97,1.09,1.1,0.94,0.58)
+  )
+  
+  gg <- ggplot(data = data,
+               aes(x = X,
+                   y = Y,
+                   shape = Period,
+                   color = Level)) +
+    geom_point(alpha = 0.6, size = 3) +
+    labs(x = " ",
+         y = "Value") +
+    scale_y_continuous(labels = scales::number_format(accuracy = 0.1)) +
+    guides(color = guide_legend(title = "Period", order = 1),
+           shape = guide_legend(title = "", order = 2)) +
+    theme(axis.text.x = element_text(angle = 90))
+  
+  info <- expect_doppelganger_built(gg, "so-issue")
+  
+  expect_equivalent(sum(sapply(info$data, "[[", "showlegend")), 4)
+})
 
 p <- ggplot(mtcars, aes(x = mpg, y = wt, color = factor(vs))) + 
   geom_point()
@@ -114,4 +156,3 @@ test_that("many legend items", {
   p <- ggplot(midwest, aes(category, fill = category)) + geom_bar()
   info <- expect_traces(p, length(unique(midwest$category)), "many legend items")
 })
-


### PR DESCRIPTION
This PR proposes a fix for a bug introduced with #2067 and thereby closes #2212.

Specifically #2067 added the line

https://github.com/plotly/plotly.R/blob/7fb95ed82fd34b650b3b401a64a3aec937fbb99d/R/layers2traces.R#L105

to take care of `guides(aes = "none")`. However,  this has the unwanted effect to remove legends for all aesthetics mentioned in `guides()` as can be seen from the following reprex which should show a `color` legend:

``` r
library(ggplot2)
library(plotly, warn=FALSE)

p <- ggplot(mtcars, aes(hp, mpg, color = factor(cyl))) +
  geom_point() +
  guides(color = guide_legend())

aes_no_guide <- names(vapply(p$guides, identical, logical(1), "none"))

aes_no_guide
#> [1] "colour"

ggplotly()
```

![](https://i.imgur.com/u0ED5EU.png)<!-- -->

The PR fixes that by including only those aes for which `vapply(p$guides, identical, logical(1), "none"))` is `TRUE`:

``` r
is_guide_none <- vapply(p$guides, identical, logical(1), "none")
aes_no_guide <- names(is_guide_none)[is_guide_none]

aes_no_guide
#> character(0)
```

<sup>Created on 2023-02-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>