### PR TITLE
Fix geom2trace.geompoint incorrect filling (closes #2298)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Closed #1214: Do not warn in RStudio on Windows when scattergl is used. Recent RStudio versions can render scattergl correctly.
 
+* Closed #2298: Fix fill assignment in geom_point when a single shape value was used with multiple fill and colour values mapped (@zeehio)
+
 # 4.10.2
 
 ## New features

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -767,7 +767,12 @@ geom2trace.GeomPoint <- function(data, params, p) {
   # fill is only relevant for pch %in% 21:25
   pch <- uniq(data$shape) %||% params$shape %||% GeomPoint$default_aes$shape
   if (any(idx <- pch %in% 21:25) || any(idx <- !is.null(data[["fill_plotlyDomain"]]))) {
-    L$marker$color[idx] <- aes2plotly(data, params, "fill")[idx]
+    fill_value <- aes2plotly(data, params, "fill")
+    if (length(idx) == 1) {
+      L$marker$color <- fill_value
+    } else {
+      L$marker$color[idx] <- fill_value[idx]
+    }
   }
   compact(L)
 }

--- a/tests/testthat/test-ggplot-point.R
+++ b/tests/testthat/test-ggplot-point.R
@@ -48,6 +48,16 @@ test_that("marker color inherits from fill, when appropriate", {
 })
 
 
+test_that("when marker color inherits from fill, colours are assigned correctly #2298", {
+  df <- data.frame(x = c(1,2), y = c(0,0), color = rep("yellow", 2), fill = 1:2)
+  p <- ggplot(df) +
+    geom_point(aes(x = x, y = y, fill = fill, color = color), size = 5, shape = 21) +
+    scale_fill_gradient(low = "green", high = "red")
+  pb <- plotly_build(p)
+  expect_equivalent(pb$x$data[[1]]$marker$color, c("rgba(0,255,0,1)", "rgba(255,0,0,1)"))
+})
+
+
 test_that("can plot on sub-second time scale", {
   d <- data.frame(
     x = as.POSIXct("2018-09-28 15:13:06 CDT") + 1e-3 * c(1:9, 5000), 


### PR DESCRIPTION
I'm unable right now to paste images here. However the plot `p` below gives a red and a green dot with ggplot2 and two green dots with plotly.

```r
  df <- data.frame(x = c(1,2), y = c(0,0), color = rep("yellow", 2), fill = 1:2)
  p <- ggplot(df) +
    geom_point(aes(x = x, y = y, fill = fill, color = color), size = 5, shape = 21) +
    scale_fill_gradient(low = "green", high = "red")
  ggplotly(p)
```

`ggplotly(p)` gives the following warning as well:

> Warning message:
>In L$marker$color[idx] <- aes2plotly(data, params, "fill")[idx] :
>  number of items to replace is not a multiple of replacement length

This PR addresses the warning and fixes the issue. It's fairly simple.