### PR TITLE
Fix rstudio windows warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Closed #1947: `ggplotly()` now correctly handles `geom_vline`/`geom_hline` with empty data. Previously, if `geom_vline`/`geom_hline` was passed an empty data frame, it would result in an error. The plot is drawn even if no lines are found; this is the same behavior as `ggplot2`.
 
+* Closed #1214: Do not warn in RStudio on Windows when scattergl is used. Recent RStudio versions can render scattergl correctly.
+
 # 4.10.2
 
 ## New features

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -395,11 +395,7 @@ plotly_build.plotly <- function(p, registerFrames = TRUE) {
   
   # if a partial bundle was specified, make sure it supports the visualization
   p <- verify_partial_bundle(p)
-  
-  # scattergl currently doesn't render in RStudio on Windows
-  # https://github.com/ropensci/plotly/issues/1214
-  p <- verify_scattergl_platform(p)
-  
+
   # make sure plots don't get sent out of the network (for enterprise)
   p$x$base_url <- get_domain()
   p

--- a/R/utils.R
+++ b/R/utils.R
@@ -948,22 +948,6 @@ verify_mathjax <- function(p) {
   p
 }
 
-verify_scattergl_platform <- function(p) {
-  if (!identical(.Platform$OS.type, "windows")) return(p)
-  if (!is_rstudio()) return(p)
-  
-  types <- vapply(p$x$data, function(x) x[["type"]] %||% "scatter", character(1))
-  if ("scattergl" %in% types) {
-    warning(
-      "'scattergl' trace types don't currently render in RStudio on Windows. ",
-      "Open in another web browser (IE, Chrome, Firefox, etc).",
-      call. = FALSE
-    )
-  }
-  
-  p
-}
-
 has_marker <- function(types, modes) {
   is_scatter <- grepl("scatter", types)
   ifelse(is_scatter, grepl("marker", modes), has_attr(types, "marker"))


### PR DESCRIPTION
The RStudio on Windows with scattergl is working for me as documented in #2296.

I'd say this closes #1214.

I would appreciate if someone (@daattali ?) who had issues with webgl rstudio and windows could verify the issues are also solved for them by running this on RStudio and seeing the plot in the viewer panel:

```r
library(ggplot2)
library(plotly)

gplt <- ggplot(iris) + geom_point(aes(x= Sepal.Length, y = Sepal.Width))
gplt |> toWebGL()
```

Thanks!