### PR TITLE
Remove footer from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,3 @@ guidelines](https://github.com/plotly/plotly.R/blob/master/CONTRIBUTING.md).
 Included are directions for opening issues, asking questions,
 contributing changes to plotly, and our code of
 conduct.
-
------
-
-![<https://ropensci.org>](https://www.ropensci.org/public_images/github_footer.png)


### PR DESCRIPTION
I suggest removing this old rOpenSci footer from the package README, as it can confuse users about the current status of this package.  We're very glad to have been a home for this package in its early days and would be happy if you wanted to note that somewhere in the repo or documentation.