### PR TITLE
Isolate `names(...)` in `event_data()` to prevent spurious updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # plotly (development version)
 
+## Bug fixes
+
+* Closed #2337: Creating a new `event_data()` handler no longer causes a spurious reactive update of existing `event_data()`s. (#2339)
+
 # 4.10.4
 
 ## Improvements

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -193,7 +193,7 @@ event_data <- function(
     
   } else {
     
-    eventHasStorage <- eventID %in% names(session$userData$plotlyInputStore)
+    eventHasStorage <- eventID %in% shiny::isolate(names(session$userData$plotlyInputStore))
     
     if (!eventHasStorage) {
       # store input value as a reactive value to leverage caching


### PR DESCRIPTION
Closes #2337 by wrapping `names(session$userData$plotlyInputStore)` with `shiny::isolate()`.

I don't think there's any good way to write an automated test for this, but you can verify that the reprex I gave in the issue no longer produces the spurious updates, while the click data continues to be correctly displayed.