### PR TITLE
Add implicit Suggests 's2' explicitly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,6 @@ Suggests:
     webshot,
     listviewer,
     dendextend,
-    s2,
     sf,
     png,
     IRdisplay,
@@ -86,4 +85,5 @@ Config/Needs/check:
     tidyverse/ggplot2,
     rcmdcheck,
     devtools,
-    reshape2
+    reshape2,
+    s2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,7 @@ Suggests:
     webshot,
     listviewer,
     dendextend,
+    s2,
     sf,
     png,
     IRdisplay,


### PR DESCRIPTION
As seen here and a few other places:

https://github.com/plotly/plotly.R/blob/44499f21d5610175d2ca65c202fbe07dac41d6f6/tests/testthat/test-ggplot-sf.R#L4