### PR TITLE
Compatibility with incoming ggplot2 changes

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -277,6 +277,11 @@ gg2list <- function(p, width = NULL, height = NULL,
     
     # Compute aesthetics to produce data with generalised variable names
     data <- by_layer(function(l, d) l$compute_aesthetics(d, plot))
+    if (exists("setup_plot_labels", envir = asNamespace("ggplot2"))) {
+      # Mirror ggplot2/#5879
+      plot$labels <- ggfun("setup_plot_labels")(plot, layers, data)
+    }
+    
     
     # add frame to group if it exists
     data <- lapply(data, function(d) { 

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -766,7 +766,7 @@ geom2trace.GeomPoint <- function(data, params, p) {
     hoveron = hover_on(data)
   )
   # fill is only relevant for pch %in% 21:25
-  pch <- uniq(data$shape) %||% params$shape %||% GeomPoint$default_aes$shape
+  pch <- uniq(data$shape) %||% params$shape %||% GeomPoint$use_defaults(NULL)$shape
   if (any(idx <- pch %in% 21:25) || any(idx <- !is.null(data[["fill_plotlyDomain"]]))) {
     fill_value <- aes2plotly(data, params, "fill")
     if (length(idx) == 1) {
@@ -866,6 +866,9 @@ geom2trace.GeomPolygon <- function(data, params, p) {
 
 #' @export
 geom2trace.GeomBoxplot <- function(data, params, p) {
+  # marker styling must inherit from GeomPoint$default_aes
+  # https://github.com/hadley/ggplot2/blob/ab42c2ca81458b0cf78e3ba47ed5db21f4d0fc30/NEWS#L73-L7
+  point_defaults <- GeomPoint$use_defaults(NULL)
   compact(list(
     x = data[["x"]],
     y = data[["y"]],
@@ -879,16 +882,15 @@ geom2trace.GeomBoxplot <- function(data, params, p) {
       aes2plotly(data, params, "fill"),
       aes2plotly(data, params, "alpha")
     ),
-    # marker styling must inherit from GeomPoint$default_aes
-    # https://github.com/hadley/ggplot2/blob/ab42c2ca81458b0cf78e3ba47ed5db21f4d0fc30/NEWS#L73-L77
+    # markers/points
     marker = list(
-      opacity = GeomPoint$default_aes$alpha,
-      outliercolor = toRGB(GeomPoint$default_aes$colour),
+      opacity = point_defaults$alpha,
+      outliercolor = toRGB(point_defaults$colour),
       line = list(
-        width = mm2pixels(GeomPoint$default_aes$stroke),
-        color = toRGB(GeomPoint$default_aes$colour)
+        width = mm2pixels(point_defaults$stroke),
+        color = toRGB(point_defaults$colour)
       ),
-      size = mm2pixels(GeomPoint$default_aes$size)
+      size = mm2pixels(point_defaults$size)
     ),
     line = list(
       color = aes2plotly(data, params, "colour"),
@@ -1101,7 +1103,7 @@ aes2plotly <- function(data, params, aes = "size") {
   if (is.null(vals)) {
     # Hack to support this geom_sf hack 
     # https://github.com/tidyverse/ggplot2/blob/505e4bfb/R/sf.R#L179-L187
-    defaults <- if (inherits(data, "GeomSf")) {
+    defaults <- if (inherits(data, "GeomSf") && exists("default_aesthetics", envir = asNamespace("ggplot2"))) {
       type <- if (any(grepl("[P-p]oint", class(data)))) "point" else if (any(grepl("[L-l]ine", class(data)))) "line" else ""
       ggfun("default_aesthetics")(type)
     } else {
@@ -1110,7 +1112,7 @@ aes2plotly <- function(data, params, aes = "size") {
       # ggfun() returns a function because ggplot2 now
       # defines data.frame in it's namespace
       # https://github.com/ropensci/plotly/pull/1481
-      if ("default_aes" %in% names(geom_obj)) geom_obj$default_aes else NULL
+      if ("default_aes" %in% names(geom_obj)) geom_obj$use_defaults(NULL) else NULL
     }
     vals <- defaults[[aes]]
   }

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -1096,21 +1096,26 @@ ribbon_dat <- function(dat) {
 aes2plotly <- function(data, params, aes = "size") {
   geom <- class(data)[1]
   
-  # Hack to support this geom_sf hack 
-  # https://github.com/tidyverse/ggplot2/blob/505e4bfb/R/sf.R#L179-L187
-  defaults <- if (inherits(data, "GeomSf")) {
-    type <- if (any(grepl("[P-p]oint", class(data)))) "point" else if (any(grepl("[L-l]ine", class(data)))) "line" else ""
-    ggfun("default_aesthetics")(type)
-  } else {
-    geom_obj <- ggfun(geom)
-    # If the first class of `data` is a data.frame,
-    # ggfun() returns a function because ggplot2 now
-    # defines data.frame in it's namespace
-    # https://github.com/ropensci/plotly/pull/1481
-    if ("default_aes" %in% names(geom_obj)) geom_obj$default_aes else NULL
-  }
+  vals <- uniq(data[[aes]]) %||% params[[aes]]
   
-  vals <- uniq(data[[aes]]) %||% params[[aes]] %||% defaults[[aes]] %||% NA
+  if (is.null(vals)) {
+    # Hack to support this geom_sf hack 
+    # https://github.com/tidyverse/ggplot2/blob/505e4bfb/R/sf.R#L179-L187
+    defaults <- if (inherits(data, "GeomSf")) {
+      type <- if (any(grepl("[P-p]oint", class(data)))) "point" else if (any(grepl("[L-l]ine", class(data)))) "line" else ""
+      ggfun("default_aesthetics")(type)
+    } else {
+      geom_obj <- ggfun(geom)
+      # If the first class of `data` is a data.frame,
+      # ggfun() returns a function because ggplot2 now
+      # defines data.frame in it's namespace
+      # https://github.com/ropensci/plotly/pull/1481
+      if ("default_aes" %in% names(geom_obj)) geom_obj$default_aes else NULL
+    }
+    vals <- defaults[[aes]]
+  }
+  vals <- vals %||% NA
+  
   converter <- switch(
     aes, 
     size = mm2pixels,

--- a/tests/testthat/test-ggplot-area.R
+++ b/tests/testthat/test-ggplot-area.R
@@ -26,9 +26,10 @@ test_that("sanity check for geom_area", {
   expect_identical(L$data[[1]]$type, "scatter")
   expect_identical(L$data[[1]]$mode, "lines")
   expect_identical(L$data[[1]]$fill, "toself")
+  area_defaults <- GeomArea$use_defaults(NULL)
   expect_true(
     L$data[[1]]$fillcolor ==
-    toRGB(GeomArea$default_aes$fill, GeomArea$default_aes$alpha)
+    toRGB(area_defaults$fill, area_defaults$alpha)
   )
 })
 
@@ -40,7 +41,7 @@ test_that("transparency alpha in geom_area is converted", {
   expect_true(L$data[[1]]$line$color == "transparent")
   expect_true(
     L$data[[1]]$fillcolor == 
-    toRGB(GeomArea$default_aes$fill, 0.4)
+    toRGB(GeomArea$use_defaults(NULL)$fill, 0.4)
   )
 })
 

--- a/tests/testthat/test-ggplot-point.R
+++ b/tests/testthat/test-ggplot-point.R
@@ -29,7 +29,7 @@ test_that("marker color is non-transparent for open shapes", {
     grepl("open$", info$data[[1]]$marker$symbol)
   )
   expect_true(
-    info$data[[1]]$marker$color == toRGB(GeomPoint$default_aes$colour)
+    info$data[[1]]$marker$color == toRGB(GeomPoint$use_defaults(NULL)$colour)
   )
 })
 

--- a/tests/testthat/test-ggplot-quantile.R
+++ b/tests/testthat/test-ggplot-quantile.R
@@ -20,7 +20,7 @@ test_that("Basic geom_quantile() works", {
     expect_equivalent(tr$type, "scatter")
     expect_equivalent(tr$mode, "lines")
     expect_equivalent(
-      tr$line$color, toRGB(GeomQuantile$default_aes[["colour"]])
+      tr$line$color, toRGB(GeomQuantile$use_defaults(NULL)[["colour"]])
     )
   }
   


### PR DESCRIPTION
Hi Carson and other maintainers,

Apologies for the cold PR!
While building a new feature in ggplot2 we found through reverse dependency checks that {plotly} was negatively affected by the changes we'd like to implement. The new feature makes extensive use of computed values in the `Geom$default_aes` field, contrasted by mostly fixed values in the current CRAN version. Mostly, this PR resolves the relevant defaults before using them in {plotly}. The changes herein should be backwards compatible (locally tested with ggplot2 3.5.1).

In addition, a small change with regards to label setup is sneaked in for good measure.
If you rather have a separate PR for that I'll prepare one.

We don't intend to release a new version of ggplot2 this year, so there isn't much of a hurry to merge this.