### PR TITLE
Bug fix. Account for multi_line=FALSE when facet rows/cols are missing. Closes #2341.

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -917,11 +917,15 @@ gg2list <- function(p, width = NULL, height = NULL,
     # facet strips -> plotly annotations
     if (has_facet(plot)) {
       col_vars <- ifelse(inherits(plot$facet, "FacetWrap"), "facets", "cols")
-      col_txt <- paste(
-        plot$facet$params$labeller(
-          lay[names(plot$facet$params[[col_vars]])]
-        ), collapse = br()
-      )
+      col_txt <- if (!length(names(plot$facet$params[[col_vars]])) == 0) {
+        paste(
+          plot$facet$params$labeller(
+            lay[names(plot$facet$params[[col_vars]])]
+          ), collapse = br()
+        )
+      } else {
+        ""
+      }
       if (is_blank(theme[["strip.text.x"]])) col_txt <- ""
       if (inherits(plot$facet, "FacetGrid") && lay$ROW != 1) col_txt <- ""
       if (robust_nchar(col_txt) > 0) {
@@ -934,22 +938,30 @@ gg2list <- function(p, width = NULL, height = NULL,
         strip <- make_strip_rect(xdom, ydom, theme, "top")
         gglayout$shapes <- c(gglayout$shapes, strip)
       }
-      row_txt <- paste(
-        plot$facet$params$labeller(
-          lay[names(plot$facet$params$rows)]
-        ), collapse = br()
-      )
-      if (is_blank(theme[["strip.text.y"]])) row_txt <- ""
-      if (inherits(plot$facet, "FacetGrid") && lay$COL != nCols) row_txt <- ""
-      if (robust_nchar(row_txt) > 0) {
-        row_lab <- make_label(
-          row_txt, x = max(xdom), y = mean(ydom),
-          el = theme[["strip.text.y"]] %||% theme[["strip.text"]],
-          xanchor = "left", yanchor = "middle"
-        )
-        gglayout$annotations <- c(gglayout$annotations, row_lab)
-        strip <- make_strip_rect(xdom, ydom, theme, "right")
-        gglayout$shapes <- c(gglayout$shapes, strip)
+      # Only FacetGrid has no cols
+      if (inherits(plot$facet, "FacetGrid")) {
+        row_txt <- if (!length(names(plot$facet$params$rows)) == 0) {
+          paste(
+            plot$facet$params$labeller(
+              lay[names(plot$facet$params$rows)]
+            ),
+            collapse = br()
+          )
+        } else {
+          ""
+        }
+        if (is_blank(theme[["strip.text.y"]])) row_txt <- ""
+        if (lay$COL != nCols) row_txt <- ""
+        if (robust_nchar(row_txt) > 0) {
+          row_lab <- make_label(
+            row_txt, x = max(xdom), y = mean(ydom),
+            el = theme[["strip.text.y"]] %||% theme[["strip.text"]],
+            xanchor = "left", yanchor = "middle"
+          )
+          gglayout$annotations <- c(gglayout$annotations, row_lab)
+          strip <- make_strip_rect(xdom, ydom, theme, "right")
+          gglayout$shapes <- c(gglayout$shapes, strip)
+        }  
       }
     }
   } # end of panel loop

--- a/tests/testthat/test-ggplot-facets.R
+++ b/tests/testthat/test-ggplot-facets.R
@@ -131,6 +131,47 @@ test_that("facet_grid translates simple labeller function", {
   )
 })
 
+g <- ggplot(mtcars, aes(mpg, wt)) + 
+  geom_point() +
+  facet_wrap( ~ vs + am, labeller = function(x) label_both(x, multi_line = FALSE))
+
+test_that("facet_wrap accounts for multi_line=FALSE", {
+  info <- expect_doppelganger_built(g, "facet_wrap-labeller-no-multi-line")
+  txt <- sapply(info$layout$annotations, "[[", "text")
+  expect_true(all(!grepl("expression(list())", txt, fixed = TRUE)))
+  expect_true(
+    all(c("vs, am: 0, 0", "vs, am: 0, 1", "vs, am: 1, 0", "vs, am: 1, 1") %in% txt)
+  )
+  expect_identical(length(txt), 6L)
+})
+
+g <- ggplot(mtcars, aes(mpg, wt)) + 
+  geom_point()
+
+g_no_col <- g +
+  facet_grid(vs + am ~ ., labeller = function(x) label_both(x, multi_line = FALSE))
+
+g_no_row <- g +
+  facet_grid(. ~ vs + am, labeller = function(x) label_both(x, multi_line = FALSE))
+
+test_that("facet_grid accounts for multi_line=FALSE", {
+  info <- expect_doppelganger_built(g_no_col, "facet_grid-labeller-no-col")
+  txt <- sapply(info$layout$annotations, "[[", "text")
+  expect_true(all(!grepl("expression(list())", txt, fixed = TRUE)))
+  expect_true(
+    all(c("vs, am: 0, 0", "vs, am: 0, 1", "vs, am: 1, 0", "vs, am: 1, 1") %in% txt)
+  )
+  expect_identical(length(txt), 6L)
+  
+  info <- expect_doppelganger_built(g_no_row, "facet_grid-labeller-no-col")
+  txt <- sapply(info$layout$annotations, "[[", "text")
+  expect_true(all(!grepl("expression(list())", txt, fixed = TRUE)))
+  expect_true(
+    all(c("vs, am: 0, 0", "vs, am: 0, 1", "vs, am: 1, 0", "vs, am: 1, 1") %in% txt)
+  )
+  expect_identical(length(txt), 6L)
+})
+
 p <- economics %>% tidyr::gather(variable, value, -date) %>% 
   qplot(data = ., date, value) + 
   facet_wrap(~variable, scale = "free_y", ncol = 2)


### PR DESCRIPTION
This PR proposes a fix to account for `multi_line=FALSE` in facet labeller functions, thereby closing #2341 .

The underlying issue is that `ggplotly()` creates a strip text for facet rows/cols even if these are missing, e.g. in case of `facet_wrap` a rows text is created in https://github.com/plotly/plotly.R/blob/3cf17c00477e6992cde648c6e711d5b464b04439/R/ggplotly.R#L937-L941
although in this case `plot$facets$params`  has no `rows` element and hence `plot$facets$params$rows` is `NULL`.

This does not result in an issue as long as `multi_line=TRUE` (which is the default for the `label_xxx` family of functions) as in this case the `label_xxx` family of functions will return an empty `list` which gets "coerced" to an empty string. However, with `multi_line=FALSE` the returned `list` is wrapped in `expression` and as a result gets coerced to a string `"expression(list())"` giving rise to the issue reported in #2341 .

In case of `facet_wrap` this can be fixed by creating a rows text only if `inherits(plot$facet, "FacetGrid")` is `TRUE`. However, the same issue arises with `facet_grid` when the rows/cols are missing:

``` r
library(plotly, warn=FALSE)
#> Loading required package: ggplot2

g <- ggplot(mtcars, aes(mpg, wt)) +
  geom_point() +
  facet_grid(vs + am ~ .,
    labeller = function(x) label_both(x, multi_line = FALSE)
  )

ggplotly()
```

![](https://i.imgur.com/rPKogPE.png)<!-- -->

<sup>Created on 2024-08-05 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

To account for this case the PR adds an `if` to check that there is anything to label.