### PR TITLE
Fix. Account for the "data_array" property of the "values" attribute of the "dimensions" attribute. Closes #2385

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Closed #2337: Creating a new `event_data()` handler no longer causes a spurious reactive update of existing `event_data()`s. (#2339)
 
+* Closed #2385: `"parcoords"`, `"parcats"` and `"splom"` traces now work with one-dimensional data by accounting for the "data_array" property of the "values" attribute of "dimensions".
+
 # 4.10.4
 
 ## Improvements

--- a/R/utils.R
+++ b/R/utils.R
@@ -551,7 +551,15 @@ verify_attr <- function(proposed, schema, layoutAttr = FALSE) {
     
     # do the same for "sub-attributes"
     if (identical(role, "object") && is.recursive(proposed[[attr]])) {
-      proposed[[attr]] <- verify_attr(proposed[[attr]], attrSchema, layoutAttr = layoutAttr)
+      # The "dimensions" attribute requires a special treatment as 
+      # it is an unnamed list and hence will be skipped by `for (attr in names(proposed))
+      if (attr == "dimensions") {
+        proposed[[attr]] <- lapply(proposed[[attr]], \(x) {
+          verify_attr(x, attrSchema$items$dimension, layoutAttr = layoutAttr)
+        })  
+      } else {
+        proposed[[attr]] <- verify_attr(proposed[[attr]], attrSchema, layoutAttr = layoutAttr)  
+      }
     }
   }
   

--- a/tests/testthat/test-plotly-parcats.R
+++ b/tests/testthat/test-plotly-parcats.R
@@ -5,25 +5,13 @@ expect_traces <- function(p, n.traces, name) {
   L
 }
 
-test_that("No cartesian axes are supplied to a splom chart", {
-  
-  p <- plot_ly(
-    type = 'splom',
-    dimensions = list(
-      list(values=c(1,2,3), label="A"),
-      list(values=c(2,5,6), label="B")
-    )
-  )
-  
-})
-
 test_that("values property has a class of AsIs", {
   p <- plot_ly(
-    type = "splom",
     dimensions = list(
-      list(values = 1, label = "A"),
-      list(values = 2, label = "B")
-    )
+      list(values = "A"),
+      list(values = "B")
+    ),
+    type = "parcats"
   )
   l <- expect_traces(p, 1, "parcats-data-array")
   tr <- l$data[[1]]$dimensions

--- a/tests/testthat/test-plotly-parcoords.R
+++ b/tests/testthat/test-plotly-parcoords.R
@@ -5,27 +5,15 @@ expect_traces <- function(p, n.traces, name) {
   L
 }
 
-test_that("No cartesian axes are supplied to a splom chart", {
-  
-  p <- plot_ly(
-    type = 'splom',
-    dimensions = list(
-      list(values=c(1,2,3), label="A"),
-      list(values=c(2,5,6), label="B")
-    )
-  )
-  
-})
-
 test_that("values property has a class of AsIs", {
   p <- plot_ly(
-    type = "splom",
     dimensions = list(
-      list(values = 1, label = "A"),
-      list(values = 2, label = "B")
-    )
+      list(label = "A", values = 3),
+      list(label = "B", values = 8)
+    ),
+    type = "parcoords"
   )
-  l <- expect_traces(p, 1, "parcats-data-array")
+  l <- expect_traces(p, 1, "parcoords-data-array")
   tr <- l$data[[1]]$dimensions
   expect_true(inherits(tr[[1]]$values, "AsIs"))
   expect_true(inherits(tr[[2]]$values, "AsIs"))


### PR DESCRIPTION
This PR proposes a fix to account for the "data_array" property of the "values" attribute of the "dimensions" attribute used in special traces like  "parcoords", "parcats" and "splom" traces thereby closing #2385.

Currently, when an attribute has the "data_array" attribute it gets wrapped in `AsIs` inside `verify_attr`. However, this check gets skipped for the `dimensions` attribute as it is an unnamed list. Additionally, the schema specs for the `values` attribute are somewhat nested.

To account for that the PR adds some special treatment for `dimensions` attribute to `verify_attr` which uses `lapply` to loop over the items of the `dimensions` list.

With the proposed fix the examples documented in #2385 work fine, e.g. for `"parcats"`:

``` r
library(plotly, warn=FALSE)
#> Loading required package: ggplot2

dd <- data.frame(
  from = "A",
  to = "B"
)

plot_ly(dd) %>%
  add_trace(
    type = "parcats",
    dimensions = list(
      list(values = ~from),
      list(values = ~to)
    )
  )
```

![](https://i.imgur.com/FWuPZtn.png)<!-- -->

<sup>Created on 2024-08-31 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>