### PR TITLE
chore: enforce Posix newline chars (`\n`) in RStudio

### DIFF
--- a/plotly.Rproj
+++ b/plotly.Rproj
@@ -13,6 +13,7 @@ RnwWeave: knitr
 LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
+LineEndingConversion: Posix
 
 BuildType: Package
 PackageUseDevtools: Yes


### PR DESCRIPTION
Relevant when developing on Windows.