### PR TITLE
include boxmode as valid attr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 ## Bug fixes
 
 * Closed #2337: Creating a new `event_data()` handler no longer causes a spurious reactive update of existing `event_data()`s. (#2339)
+* Closed #2376: Removes errant boxmode warning for grouped boxplot. (#2396)
 
 # 4.10.4
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -449,7 +449,7 @@ verify_attr_names <- function(p) {
   # some layout attributes (e.g., [x-y]axis can have trailing numbers)
   attrs_name_check(
     sub("[0-9]+$", "", names(p$x$layout)),
-    c(names(Schema$layout$layoutAttributes), c("barmode", "bargap", "mapType")),
+    c(names(Schema$layout$layoutAttributes), c("boxmode", "barmode", "bargap", "mapType")),
     "layout"
   )
   attrs_name_check(


### PR DESCRIPTION
Fix for #2376 and #994.
Simply adds boxmode as a valid attribute option in the attrs_name_check function of utils.R.

Warning no longer appears for boxmode option.

Tests run without error or warning.

@cpsievert @KasperSkytte