### PR TITLE
Support factor variables for x and/or y when numeric variable is used to set color

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 ## Bug fixes
 
 * Closed #2337: Creating a new `event_data()` handler no longer causes a spurious reactive update of existing `event_data()`s. (#2339)
+* Support factor variables for x and/or y when numeric variable is used to set color
 
 # 4.10.4
 

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -872,9 +872,14 @@ map_color <- function(traces, stroke = FALSE, title = "", colorway, na.color = "
     # add an "empty" trace with the colorbar
     colorObj$color <- rng
     colorObj$showscale <- default(TRUE)
+    # extract range for numeric variables
+    xValues <- unlist(lapply(traces, "[[", "x"))
+    xValues <- if (is.numeric(xValues)) range(xValues, na.rm = TRUE) else xValues
+    yValues <- unlist(lapply(traces, "[[", "y"))
+    yValues <- if (is.numeric(yValues)) range(yValues, na.rm = TRUE) else yValues
     colorBarTrace <- list(
-      x = range(unlist(lapply(traces, "[[", "x")), na.rm = TRUE),
-      y = range(unlist(lapply(traces, "[[", "y")), na.rm = TRUE),
+      x = xValues,
+      y = yValues,
       type = if (any(types %in% glTypes())) "scattergl" else "scatter",
       mode = "markers",
       opacity = 0,


### PR DESCRIPTION
Support factor variables for x and/or y when numeric variable is used to set color.

See https://stackoverflow.com/questions/45217616/colors-in-plotly-range-not-meaningful-for-factors. The proposed workaround does not honour the order of the factor levels.