### PR TITLE
Add an `suppress_unregistered_warning` parameter to `event_data()` to prevent spurious warnings in apps with conditionally-rendered plots.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,7 @@ Suggests:
     rsvg,
     ggridges
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Config/Needs/check:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `ggplotly()` now supports the `{ggridges}` package. (#2314)
 
+* `event_data()` has a new `suppress_unregistered_warning` parameter. The relevant warning message has also been updated to reflect that it is often spurious in apps with conditionally-rendered plots (e.g. dashboard apps with multiple tabs). (#1528, #1538)
+
 ## Improvements
 
 * `ggplotly()` now works better with the development version of ggplot2 (> v3.4.4). (#2315, #2368)

--- a/man/event_data.Rd
+++ b/man/event_data.Rd
@@ -12,7 +12,8 @@ event_data(
     "plotly_sunburstclick"),
   source = "A",
   session = shiny::getDefaultReactiveDomain(),
-  priority = c("input", "event")
+  priority = c("input", "event"),
+  suppress_unregistered_warning = FALSE
 )
 }
 \arguments{
@@ -29,6 +30,11 @@ events emitted from that specific plot.}
 If equal to \code{"event"}, then \code{\link[=event_data]{event_data()}} always triggers re-execution,
 instead of re-executing only when the relevant shiny input value changes
 (the default).}
+
+\item{suppress_unregistered_warning}{If TRUE, do not throw a warning when
+this function is called before a plot renders and registers event handlers.
+(These warnings often occur spuriously in multi-tab apps, where not all plots
+are immediately rendered.)}
 }
 \description{
 This function must be called within a reactive shiny context.


### PR DESCRIPTION
https://github.com/plotly/plotly.R/issues/1528#issuecomment-2514223180 is an in-depth overview of why this option is necessary.