### PR TITLE
Fix annotation bug in plotly_build.R

### DIFF
--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -49,7 +49,12 @@ plotly_build.plotly <- function(p, registerFrames = TRUE) {
     x <- rapply(x, eval_attr, data = d, how = "list")
     
     # if an annotation attribute is an array, expand into multiple annotations
-    nAnnotations <- max(lengths(x$annotations) %||% 0)
+    
+    # Remove any elements from x$annotations that are of class 'list'
+    # this will remove the 'font' attribute list while retaining relevent attributes
+    x_annotations_subset <- Filter(function(x) !inherits(x, "list"), x$annotations)
+    nAnnotations <- max(lengths(x_annotations_subset) %||% 0)
+                                   
     if (!is.null(names(x$annotations))) {
       # font is the only list object, so store it, and attach after transposing
       font <- x$annotations[["font"]]


### PR DESCRIPTION
Fixed a bug in which, if the plot only has one annotation but the 'font' attribute has multiple elements (such as color and size), the annotation becomes duplicated. This was due to the fact that plotly_build, when counting annotations, also counted the length of the 'font' attribute list, so if there's only one annotation but 'font' is of length 2, it created a list of 2 identical annotations. 

Now, when counting the length of annotation attributes, any attribute of class 'list' (which I believe should only apply to 'font'), is removed and not counted.