### PR TITLE
Protect list of variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 * Closed #2337: Creating a new `event_data()` handler no longer causes a spurious reactive update of existing `event_data()`s. (#2339)
 * Closed #2376: Removes errant boxmode warning for grouped boxplot. (#2396)
+* Closed #2419: Issue with NA handling in scatter plots: Two NAs per category cause incorrect line connection (#2419)
 
 # 4.10.4
 

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -995,10 +995,12 @@ traceify <- function(dat, x = NULL) {
   recurse <- function(z, n, idx) {
     if (is.list(z)) lapply(z, recurse, n, idx) else if (length(z) == n) z[idx] else z
   }
+  varMapping <- dat[[".plotlyVariableMapping"]] # Protect this value from recurse
   new_dat <- list()
   for (j in seq_along(lvls)) {
     new_dat[[j]] <- lapply(dat, function(y) recurse(y, n, x %in% lvls[j]))
     new_dat[[j]]$name <- new_dat[[j]]$name %||% lvls[j]
+    new_dat[[j]]$.plotlyVariableMapping <- varMapping
   }
   return(new_dat)
 }


### PR DESCRIPTION
If this is not done (or similar), in rare situations the `recurse` function splits the variable list into parts if it happens to match length of the column to split by.

Fixes #2419