### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -784,7 +784,7 @@ gg2list <- function(p, width = NULL, height = NULL,
       # the logic here is similar to what p$coordinates$aspect() does,
       # but the ratio is scaled to the data range by plotly.js 
       fixed_coords <- c("CoordSf", "CoordFixed", "CoordMap", "CoordQuickmap")
-      is_fixed <- !is.null(p$coordinates$is_free())
+      is_fixed <- isFALSE(p$coordinates$is_free())
       if (inherits(p$coordinates, fixed_coords) || is_fixed) {
         axisObj$scaleanchor <- anchor
         ratio <- p$coordinates$ratio %||% 1

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -784,7 +784,8 @@ gg2list <- function(p, width = NULL, height = NULL,
       # the logic here is similar to what p$coordinates$aspect() does,
       # but the ratio is scaled to the data range by plotly.js 
       fixed_coords <- c("CoordSf", "CoordFixed", "CoordMap", "CoordQuickmap")
-      if (inherits(p$coordinates, fixed_coords)) {
+      is_fixed <- !is.null(p$coordinates$is_free())
+      if (inherits(p$coordinates, fixed_coords) || is_fixed) {
         axisObj$scaleanchor <- anchor
         ratio <- p$coordinates$ratio %||% 1
         axisObj$scaleratio <- if (xy == "y") ratio else 1 / ratio

--- a/tests/testthat/test-ggplot-labels.R
+++ b/tests/testthat/test-ggplot-labels.R
@@ -51,6 +51,6 @@ test_that("empty labels work", {
   p <- ggplot(palmerpenguins::penguins, 
               aes(bill_length_mm, bill_depth_mm, color = species)) + 
     geom_point() + 
-    labs(x = element_blank(), y = element_blank())
+    labs(x = NULL, y = NULL)
   b <- expect_doppelganger_built(p, "labs-element-blank")
 })


### PR DESCRIPTION
Hi Carson,

We're preparing a new major version of ggplot2 and during a revdepcheck we bumped into a few things we think are best adressed in plotly rather than ggplot2.
I'm still getting a few node stack errors that I can't trace to ggplot2 or reproduce when re-running the relevant test file, so perhaps it'll be false alarm.
We plan to release the new ggplot2 version soon, so it'd be great if a compatible version of plotly was already on CRAN.

Best wishes,
Teun