### PR TITLE
Add valid attribute fill for trace type "box"

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -460,10 +460,14 @@ verify_attr_names <- function(p) {
   for (tr in seq_along(p$x$data)) {
     thisTrace <- p$x$data[[tr]]
     attrSpec <- Schema$traces[[thisTrace$type %||% "scatter"]]$attributes
+    attrSpec_names <- c(names(attrSpec), "key", "set", "frame", "transforms", "_isNestedKey", "_isSimpleKey", "_isGraticule", "_bbox", "fill")
+    if(!is.null(thisTrace$type) && thisTrace$type == "box"){
+      attrSpec_names <- c(attrSpec_names, "box")
+    }
     # make sure attribute names are valid
     attrs_name_check(
       names(thisTrace), 
-      c(names(attrSpec), "key", "set", "frame", "transforms", "_isNestedKey", "_isSimpleKey", "_isGraticule", "_bbox"), 
+      attrSpec_names, 
       thisTrace$type
     )
   }


### PR DESCRIPTION
The "fill" attribute can be used in combination with the box trace type to provide colours to box plots. This is particularly useful to enable corroboration between traces of different types.
For example, between colours used for point/scatter traces and box traces. 
This change sets fill as a valid attribute where thisTrace$type == "box". 

Including this attribute as valid in the source .json file may be an alternative fix for the inaccurate/non-specific warning message.