### PR TITLE
`collaborate` is no longer a supported option for `config` and should not be included in the examples

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -105,8 +105,8 @@ rangeslider <- function(p, start = NULL, end = NULL, ...) {
 #' @export
 #' @examplesIf interactive() || !identical(.Platform$OS.type, "windows")
 #' 
-#' # remove the plotly logo and collaborate button from modebar
-#' config(plot_ly(), displaylogo = FALSE, collaborate = FALSE)
+#' # remove the plotly logo and 2D lasso option from modebar
+#' config(plot_ly(), displaylogo = FALSE, modeBarButtonsToRemove = list("lasso2d"))
 #' 
 #' # enable mathjax
 #' # see more examples at https://plotly.com/r/LaTeX/

--- a/man/config.Rd
+++ b/man/config.Rd
@@ -42,8 +42,8 @@ Set the default configuration for plotly
 \examples{
 \dontshow{if (interactive() || !identical(.Platform$OS.type, "windows")) withAutoprint(\{ # examplesIf}
 
-# remove the plotly logo and collaborate button from modebar
-config(plot_ly(), displaylogo = FALSE, collaborate = FALSE)
+# remove the plotly logo and 2D lasso option from modebar
+config(plot_ly(), displaylogo = FALSE, modeBarButtonsToRemove = list("lasso2d"))
 
 # enable mathjax
 # see more examples at https://plotly.com/r/LaTeX/

--- a/tests/testthat/test-plotly.R
+++ b/tests/testthat/test-plotly.R
@@ -303,6 +303,12 @@ test_that("Informative deprecation message for titlefont", {
   expect_warning(config(plot_ly(), cloud = TRUE), "cloud")
 })
 
+test_that("Informative deprecation message for collaborate", {
+  p <- plot_ly(x = 1:3, mode = "markers", type = "scatter")
+  expect_warning(config(p, collaborate=TRUE), regexp = "collaborate button")
+  expect_warning(config(p, collaborate=FALSE), regexp = "collaborate button")
+})
+
 test_that("Informative warning for invalid config attr", {
   p <- config(plot_ly(), foobar = TRUE)
   expect_warning(plotly_build(p), "foobar")


### PR DESCRIPTION
Ran into an unexpected warning when trying to run the `config` examples because the `collaborate` argument that it uses has since been deprecated. This PR removes that arg from the example and uses a different one (disabling the "lasso" option via `modeBarButtonsToRemove = list("lasso2d")`) instead. Unit test for the "collaborate" warning has been added and docs have been rebuilt for that part of the file specifically.