### PR TITLE
Complete plot_ly type documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # plotly (development version)
 
+* Completed the `plot_ly()` documentation for what happens when `type` is not
+  specified (#2362).
+
 * Removed the dependency on the `{lazyeval}` package.
 
 ## Bug fixes

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -22,7 +22,8 @@
 #' provided at this level may override other arguments 
 #' (e.g. `plot_ly(x = 1:10, y = 1:10, color = I("red"), marker = list(color = "blue"))`).
 #' @param type A character string specifying the trace type (e.g. `"scatter"`, `"bar"`, `"box"`, etc).
-#' If specified, it *always* creates a trace, otherwise 
+#' If specified, it *always* creates a trace. Otherwise, a trace type is
+#' inferred from the supplied arguments when the plot is built.
 #' @param name Values mapped to the trace's name attribute. Since a trace can 
 #' only have one name, this argument acts very much like `split` in that it 
 #' creates one trace for every unique value.

--- a/man/plot_ly.Rd
+++ b/man/plot_ly.Rd
@@ -40,7 +40,8 @@ provided at this level may override other arguments
 (e.g. \code{plot_ly(x = 1:10, y = 1:10, color = I("red"), marker = list(color = "blue"))}).}
 
 \item{type}{A character string specifying the trace type (e.g. \code{"scatter"}, \code{"bar"}, \code{"box"}, etc).
-If specified, it \emph{always} creates a trace, otherwise}
+If specified, it \emph{always} creates a trace. Otherwise, a trace type is
+inferred from the supplied arguments when the plot is built.}
 
 \item{name}{Values mapped to the trace's name attribute. Since a trace can
 only have one name, this argument acts very much like \code{split} in that it


### PR DESCRIPTION
Fixes #2362.

This completes the `type` parameter documentation for `plot_ly()` by explaining what happens when `type` is not specified.

Checks:
- `Rscript -e 'tools::checkRd("man/plot_ly.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `R_LIBS_USER=/tmp/plotly-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests plotly_4.12.0.9000.tar.gz`